### PR TITLE
Update color in query/mutation comment

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/FieldDoc.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/FieldDoc.tsx
@@ -87,6 +87,9 @@ export default class FieldDoc extends React.Component<Props, State> {
           .doc-description {
             @p: .ph16, .black50;
           }
+          .doc-type-description {
+            @p: .black50;
+          }
         `}</style>
         <style jsx={true}>{`
           .doc-header {


### PR DESCRIPTION
A little change about the color of a comment from a query or mutation.

Before: 
<img width="290" alt="capture d ecran 2018-08-08 a 19 14 35" src="https://user-images.githubusercontent.com/2202989/43853089-5bab01ce-9b3f-11e8-81fa-e8d835a32ae7.png">


After:
<img width="297" alt="capture d ecran 2018-08-08 a 19 14 14" src="https://user-images.githubusercontent.com/2202989/43853101-638ccc56-9b3f-11e8-89d2-eb07ef0848c0.png">


It's take the same style `.black50` as inside the comment for a scalar for example.