### PR TITLE
Show graphql extensions

### DIFF
--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -190,7 +190,12 @@ function* runQuerySaga(action) {
       if (value && value.extensions) {
         const extensions = value.extensions
         yield put(setResponseExtensions(extensions))
-        delete value.extensions
+        if (
+          value.extensions.tracing &&
+          settings['tracing.hideTracingResponse']
+        ) {
+          delete value.extensions.tracing
+        }
       }
       const response = new ResponseRecord({
         date: JSON.stringify(value ? value : formatError(error), null, 2),


### PR DESCRIPTION
Fixes #804.

Changes proposed in this pull request:

- GraphQL Extensions are not always hidden from the results view.
- When the `tracing.hideTracingResponse` setting is enabled, tracing is hidden from the results view as advertised in the docs.