### PR TITLE
Adding default header option to GraphQLPlayground.init()

### DIFF
--- a/packages/graphql-playground-react/public/index.html
+++ b/packages/graphql-playground-react/public/index.html
@@ -1,536 +1,541 @@
+<!DOCTYPE html>
+<html>
 
-  <!DOCTYPE html>
-  <html>
-  <head>
-    <meta charset=utf-8 />
-    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-    <title>GraphQL Playground</title>
-    
-  </head>
-  <body>
-    <style type="text/css">
-      html {
-        font-family: "Open Sans", sans-serif;
-        overflow: hidden;
+<head>
+  <meta charset=utf-8 />
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>GraphQL Playground</title>
+
+</head>
+
+<body>
+  <style type="text/css">
+    html {
+      font-family: "Open Sans", sans-serif;
+      overflow: hidden;
+    }
+
+    body {
+      margin: 0;
+      background: #172a3a;
+    }
+
+    .playgroundIn {
+      -webkit-animation: playgroundIn 0.5s ease-out forwards;
+      animation: playgroundIn 0.5s ease-out forwards;
+    }
+
+    @-webkit-keyframes playgroundIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(10px);
+        -ms-transform: translateY(10px);
+        transform: translateY(10px);
       }
-  
-      body {
-        margin: 0;
-        background: #172a3a;
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
       }
-  
-      .playgroundIn {
-        -webkit-animation: playgroundIn 0.5s ease-out forwards;
-        animation: playgroundIn 0.5s ease-out forwards;
+    }
+
+    @keyframes playgroundIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(10px);
+        -ms-transform: translateY(10px);
+        transform: translateY(10px);
       }
-  
-      @-webkit-keyframes playgroundIn {
-        from {
-          opacity: 0;
-          -webkit-transform: translateY(10px);
-          -ms-transform: translateY(10px);
-          transform: translateY(10px);
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+  </style>
+
+  <style type="text/css">
+    .fadeOut {
+      -webkit-animation: fadeOut 0.5s ease-out forwards;
+      animation: fadeOut 0.5s ease-out forwards;
+    }
+
+    @-webkit-keyframes fadeIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @-webkit-keyframes fadeOut {
+      from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+      to {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+    }
+
+    @keyframes fadeOut {
+      from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+      to {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+    }
+
+    @-webkit-keyframes appearIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(0px);
+        -ms-transform: translateY(0px);
+        transform: translateY(0px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes appearIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(0px);
+        -ms-transform: translateY(0px);
+        transform: translateY(0px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @-webkit-keyframes scaleIn {
+      from {
+        -webkit-transform: scale(0);
+        -ms-transform: scale(0);
+        transform: scale(0);
+      }
+      to {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+    }
+
+    @keyframes scaleIn {
+      from {
+        -webkit-transform: scale(0);
+        -ms-transform: scale(0);
+        transform: scale(0);
+      }
+      to {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+    }
+
+    @-webkit-keyframes innerDrawIn {
+      0% {
+        stroke-dashoffset: 70;
+      }
+      50% {
+        stroke-dashoffset: 140;
+      }
+      100% {
+        stroke-dashoffset: 210;
+      }
+    }
+
+    @keyframes innerDrawIn {
+      0% {
+        stroke-dashoffset: 70;
+      }
+      50% {
+        stroke-dashoffset: 140;
+      }
+      100% {
+        stroke-dashoffset: 210;
+      }
+    }
+
+    @-webkit-keyframes outerDrawIn {
+      0% {
+        stroke-dashoffset: 76;
+      }
+      100% {
+        stroke-dashoffset: 152;
+      }
+    }
+
+    @keyframes outerDrawIn {
+      0% {
+        stroke-dashoffset: 76;
+      }
+      100% {
+        stroke-dashoffset: 152;
+      }
+    }
+
+    .hHWjkv {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+    }
+
+    .gCDOzd {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+    }
+
+    .hmCcxi {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+    }
+
+    .eHamQi {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+      animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+    }
+
+    .byhgGu {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+      animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+    }
+
+    .llAKP {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+      animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+    }
+
+    .bglIGM {
+      -webkit-transform-origin: 64px 28px;
+      -ms-transform-origin: 64px 28px;
+      transform-origin: 64px 28px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+    }
+
+    .ksxRII {
+      -webkit-transform-origin: 95.98500061035156px 46.510000228881836px;
+      -ms-transform-origin: 95.98500061035156px 46.510000228881836px;
+      transform-origin: 95.98500061035156px 46.510000228881836px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+    }
+
+    .cWrBmb {
+      -webkit-transform-origin: 95.97162628173828px 83.4900016784668px;
+      -ms-transform-origin: 95.97162628173828px 83.4900016784668px;
+      transform-origin: 95.97162628173828px 83.4900016784668px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+    }
+
+    .Wnusb {
+      -webkit-transform-origin: 64px 101.97999572753906px;
+      -ms-transform-origin: 64px 101.97999572753906px;
+      transform-origin: 64px 101.97999572753906px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+      animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+    }
+
+    .bfPqf {
+      -webkit-transform-origin: 32.03982162475586px 83.4900016784668px;
+      -ms-transform-origin: 32.03982162475586px 83.4900016784668px;
+      transform-origin: 32.03982162475586px 83.4900016784668px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+      animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+    }
+
+    .edRCTN {
+      -webkit-transform-origin: 32.033552169799805px 46.510000228881836px;
+      -ms-transform-origin: 32.033552169799805px 46.510000228881836px;
+      transform-origin: 32.033552169799805px 46.510000228881836px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+      animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+    }
+
+    .iEGVWn {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .bsocdx {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .jAZXmP {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .hSeArx {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .bVgqGk {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .hEFqBt {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .dzEKCM {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    .DYnPx {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    .hjPEAQ {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    #loading-wrapper {
+      position: absolute;
+      width: 100vw;
+      height: 100vh;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .logo {
+      width: 75px;
+      height: 75px;
+      margin-bottom: 20px;
+      opacity: 0;
+      -webkit-animation: fadeIn 0.5s ease-out forwards;
+      animation: fadeIn 0.5s ease-out forwards;
+    }
+
+    .text {
+      font-size: 32px;
+      font-weight: 200;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.6);
+      opacity: 0;
+      -webkit-animation: fadeIn 0.5s ease-out forwards;
+      animation: fadeIn 0.5s ease-out forwards;
+    }
+
+    .dGfHfc {
+      font-weight: 400;
+    }
+  </style>
+  <div id="loading-wrapper">
+    <svg class="logo" viewBox="0 0 128 128" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <title>GraphQL Playground Logo</title>
+      <defs>
+        <linearGradient id="linearGradient-1" x1="4.86%" x2="96.21%" y1="0%" y2="99.66%">
+          <stop stop-color="#E00082" stop-opacity=".8" offset="0%"></stop>
+          <stop stop-color="#E00082" offset="100%"></stop>
+        </linearGradient>
+      </defs>
+      <g>
+        <rect id="Gradient" width="127.96" height="127.96" y="1" fill="url(#linearGradient-1)" rx="4"></rect>
+        <path id="Border" fill="#E00082" fill-rule="nonzero" d="M4.7 2.84c-1.58 0-2.86 1.28-2.86 2.85v116.57c0 1.57 1.28 2.84 2.85 2.84h116.57c1.57 0 2.84-1.26 2.84-2.83V5.67c0-1.55-1.26-2.83-2.83-2.83H4.67zM4.7 0h116.58c3.14 0 5.68 2.55 5.68 5.7v116.58c0 3.14-2.54 5.68-5.68 5.68H4.68c-3.13 0-5.68-2.54-5.68-5.68V5.68C-1 2.56 1.55 0 4.7 0z"></path>
+        <path class="bglIGM" x="64" y="28" fill="#fff" d="M64 36c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8" style="transform: translate(100px, 100px);"></path>
+        <path class="ksxRII" x="95.98500061035156" y="46.510000228881836" fill="#fff" d="M89.04 50.52c-2.2-3.84-.9-8.73 2.94-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.76.9-10.97-2.94"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="cWrBmb" x="95.97162628173828" y="83.4900016784668" fill="#fff" d="M102.9 87.5c-2.2 3.84-7.1 5.15-10.94 2.94-3.84-2.2-5.14-7.12-2.94-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.86 2.23 5.16 7.12 2.94 10.96"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="Wnusb" x="64" y="101.97999572753906" fill="#fff" d="M64 110c-4.43 0-8-3.6-8-8.02 0-4.44 3.57-8.02 8-8.02s8 3.58 8 8.02c0 4.4-3.57 8.02-8 8.02"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="bfPqf" x="32.03982162475586" y="83.4900016784668" fill="#fff" d="M25.1 87.5c-2.2-3.84-.9-8.73 2.93-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.74.9-10.95-2.94"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="edRCTN" x="32.033552169799805" y="46.510000228881836" fill="#fff" d="M38.96 50.52c-2.2 3.84-7.12 5.15-10.95 2.94-3.82-2.2-5.12-7.12-2.92-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.83 2.23 5.14 7.12 2.94 10.96"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="iEGVWn" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M63.55 27.5l32.9 19-32.9-19z"></path>
+        <path class="bsocdx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96 46v38-38z"></path>
+        <path class="jAZXmP" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96.45 84.5l-32.9 19 32.9-19z"></path>
+        <path class="hSeArx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M64.45 103.5l-32.9-19 32.9 19z"></path>
+        <path class="bVgqGk" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M32 84V46v38z"></path>
+        <path class="hEFqBt" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M31.55 46.5l32.9-19-32.9 19z"></path>
+        <path class="dzEKCM" id="Triangle-Bottom" stroke="#fff" stroke-width="4" d="M30 84h70" stroke-linecap="round"></path>
+        <path class="DYnPx" id="Triangle-Left" stroke="#fff" stroke-width="4" d="M65 26L30 87" stroke-linecap="round"></path>
+        <path class="hjPEAQ" id="Triangle-Right" stroke="#fff" stroke-width="4" d="M98 87L63 26" stroke-linecap="round"></path>
+      </g>
+    </svg>
+    <div class="text">Loading
+      <span class="dGfHfc">GraphQL Playground</span>
+    </div>
+  </div>
+
+  <div id="root" />
+  <script type="text/javascript">
+    window.addEventListener('load', function (event) {
+
+      const loadingWrapper = document.getElementById('loading-wrapper');
+      loadingWrapper.classList.add('fadeOut');
+
+
+      const root = document.getElementById('root');
+      root.classList.add('playgroundIn');
+
+      GraphQLPlayground.init(root, {
+        "env": "react",
+        "canSaveConfig": false,
+        "headers": {
+          "test": "test",
         }
-        to {
-          opacity: 1;
-          -webkit-transform: translateY(0);
-          -ms-transform: translateY(0);
-          transform: translateY(0);
-        }
-      }
-  
-      @keyframes playgroundIn {
-        from {
-          opacity: 0;
-          -webkit-transform: translateY(10px);
-          -ms-transform: translateY(10px);
-          transform: translateY(10px);
-        }
-        to {
-          opacity: 1;
-          -webkit-transform: translateY(0);
-          -ms-transform: translateY(0);
-          transform: translateY(0);
-        }
-      }
-    </style>
-    
-<style type="text/css">
-.fadeOut {
-  -webkit-animation: fadeOut 0.5s ease-out forwards;
-  animation: fadeOut 0.5s ease-out forwards;
-}
-
-@-webkit-keyframes fadeIn {
-  from {
-    opacity: 0;
-    -webkit-transform: translateY(-10px);
-    -ms-transform: translateY(-10px);
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    -webkit-transform: translateY(-10px);
-    -ms-transform: translateY(-10px);
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-}
-
-@-webkit-keyframes fadeOut {
-  from {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    -webkit-transform: translateY(-10px);
-    -ms-transform: translateY(-10px);
-    transform: translateY(-10px);
-  }
-}
-
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    -webkit-transform: translateY(-10px);
-    -ms-transform: translateY(-10px);
-    transform: translateY(-10px);
-  }
-}
-
-@-webkit-keyframes appearIn {
-  from {
-    opacity: 0;
-    -webkit-transform: translateY(0px);
-    -ms-transform: translateY(0px);
-    transform: translateY(0px);
-  }
-  to {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-}
-
-@keyframes appearIn {
-  from {
-    opacity: 0;
-    -webkit-transform: translateY(0px);
-    -ms-transform: translateY(0px);
-    transform: translateY(0px);
-  }
-  to {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-}
-
-@-webkit-keyframes scaleIn {
-  from {
-    -webkit-transform: scale(0);
-    -ms-transform: scale(0);
-    transform: scale(0);
-  }
-  to {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    -webkit-transform: scale(0);
-    -ms-transform: scale(0);
-    transform: scale(0);
-  }
-  to {
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-  }
-}
-
-@-webkit-keyframes innerDrawIn {
-  0% {
-    stroke-dashoffset: 70;
-  }
-  50% {
-    stroke-dashoffset: 140;
-  }
-  100% {
-    stroke-dashoffset: 210;
-  }
-}
-
-@keyframes innerDrawIn {
-  0% {
-    stroke-dashoffset: 70;
-  }
-  50% {
-    stroke-dashoffset: 140;
-  }
-  100% {
-    stroke-dashoffset: 210;
-  }
-}
-
-@-webkit-keyframes outerDrawIn {
-  0% {
-    stroke-dashoffset: 76;
-  }
-  100% {
-    stroke-dashoffset: 152;
-  }
-}
-
-@keyframes outerDrawIn {
-  0% {
-    stroke-dashoffset: 76;
-  }
-  100% {
-    stroke-dashoffset: 152;
-  }
-}
-
-.hHWjkv {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
-}
-
-.gCDOzd {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
-}
-
-.hmCcxi {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
-}
-
-.eHamQi {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
-  animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
-}
-
-.byhgGu {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
-  animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
-}
-
-.llAKP {
-  -webkit-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
-  transform-origin: 0px 0px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
-  animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
-}
-
-.bglIGM {
-  -webkit-transform-origin: 64px 28px;
-  -ms-transform-origin: 64px 28px;
-  transform-origin: 64px 28px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
-}
-
-.ksxRII {
-  -webkit-transform-origin: 95.98500061035156px 46.510000228881836px;
-  -ms-transform-origin: 95.98500061035156px 46.510000228881836px;
-  transform-origin: 95.98500061035156px 46.510000228881836px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
-}
-
-.cWrBmb {
-  -webkit-transform-origin: 95.97162628173828px 83.4900016784668px;
-  -ms-transform-origin: 95.97162628173828px 83.4900016784668px;
-  transform-origin: 95.97162628173828px 83.4900016784668px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
-  animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
-}
-
-.Wnusb {
-  -webkit-transform-origin: 64px 101.97999572753906px;
-  -ms-transform-origin: 64px 101.97999572753906px;
-  transform-origin: 64px 101.97999572753906px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
-  animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
-}
-
-.bfPqf {
-  -webkit-transform-origin: 32.03982162475586px 83.4900016784668px;
-  -ms-transform-origin: 32.03982162475586px 83.4900016784668px;
-  transform-origin: 32.03982162475586px 83.4900016784668px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
-  animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
-}
-
-.edRCTN {
-  -webkit-transform-origin: 32.033552169799805px 46.510000228881836px;
-  -ms-transform-origin: 32.033552169799805px 46.510000228881836px;
-  transform-origin: 32.033552169799805px 46.510000228881836px;
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-  -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
-  animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
-}
-
-.iEGVWn {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
-  animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.bsocdx {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
-  animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.jAZXmP {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
-  animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.hSeArx {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
-  animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.bVgqGk {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
-  animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.hEFqBt {
-  opacity: 0;
-  stroke-dasharray: 76;
-  -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
-  animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
-  -webkit-animation-iteration-count: 1, 1;
-  animation-iteration-count: 1, 1;
-}
-
-.dzEKCM {
-  opacity: 0;
-  stroke-dasharray: 70;
-  -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
-  animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
-  -webkit-animation-iteration-count: infinite, 1;
-  animation-iteration-count: infinite, 1;
-}
-
-.DYnPx {
-  opacity: 0;
-  stroke-dasharray: 70;
-  -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
-  animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
-  -webkit-animation-iteration-count: infinite, 1;
-  animation-iteration-count: infinite, 1;
-}
-
-.hjPEAQ {
-  opacity: 0;
-  stroke-dasharray: 70;
-  -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
-  animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
-  -webkit-animation-iteration-count: infinite, 1;
-  animation-iteration-count: infinite, 1;
-}
-
-#loading-wrapper {
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.logo {
-  width: 75px;
-  height: 75px;
-  margin-bottom: 20px;
-  opacity: 0;
-  -webkit-animation: fadeIn 0.5s ease-out forwards;
-  animation: fadeIn 0.5s ease-out forwards;
-}
-
-.text {
-  font-size: 32px;
-  font-weight: 200;
-  text-align: center;
-  color: rgba(255, 255, 255, 0.6);
-  opacity: 0;
-  -webkit-animation: fadeIn 0.5s ease-out forwards;
-  animation: fadeIn 0.5s ease-out forwards;
-}
-
-.dGfHfc {
-  font-weight: 400;
-}
-</style>
-<div id="loading-wrapper">
-<svg class="logo" viewBox="0 0 128 128" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>GraphQL Playground Logo</title>
-  <defs>
-    <linearGradient id="linearGradient-1" x1="4.86%" x2="96.21%" y1="0%" y2="99.66%">
-      <stop stop-color="#E00082" stop-opacity=".8" offset="0%"></stop>
-      <stop stop-color="#E00082" offset="100%"></stop>
-    </linearGradient>
-  </defs>
-  <g>
-    <rect id="Gradient" width="127.96" height="127.96" y="1" fill="url(#linearGradient-1)" rx="4"></rect>
-    <path id="Border" fill="#E00082" fill-rule="nonzero" d="M4.7 2.84c-1.58 0-2.86 1.28-2.86 2.85v116.57c0 1.57 1.28 2.84 2.85 2.84h116.57c1.57 0 2.84-1.26 2.84-2.83V5.67c0-1.55-1.26-2.83-2.83-2.83H4.67zM4.7 0h116.58c3.14 0 5.68 2.55 5.68 5.7v116.58c0 3.14-2.54 5.68-5.68 5.68H4.68c-3.13 0-5.68-2.54-5.68-5.68V5.68C-1 2.56 1.55 0 4.7 0z"></path>
-    <path class="bglIGM" x="64" y="28" fill="#fff" d="M64 36c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8" style="transform: translate(100px, 100px);"></path>
-    <path class="ksxRII" x="95.98500061035156" y="46.510000228881836" fill="#fff" d="M89.04 50.52c-2.2-3.84-.9-8.73 2.94-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.76.9-10.97-2.94"
-      style="transform: translate(100px, 100px);"></path>
-    <path class="cWrBmb" x="95.97162628173828" y="83.4900016784668" fill="#fff" d="M102.9 87.5c-2.2 3.84-7.1 5.15-10.94 2.94-3.84-2.2-5.14-7.12-2.94-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.86 2.23 5.16 7.12 2.94 10.96"
-      style="transform: translate(100px, 100px);"></path>
-    <path class="Wnusb" x="64" y="101.97999572753906" fill="#fff" d="M64 110c-4.43 0-8-3.6-8-8.02 0-4.44 3.57-8.02 8-8.02s8 3.58 8 8.02c0 4.4-3.57 8.02-8 8.02"
-      style="transform: translate(100px, 100px);"></path>
-    <path class="bfPqf" x="32.03982162475586" y="83.4900016784668" fill="#fff" d="M25.1 87.5c-2.2-3.84-.9-8.73 2.93-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.74.9-10.95-2.94"
-      style="transform: translate(100px, 100px);"></path>
-    <path class="edRCTN" x="32.033552169799805" y="46.510000228881836" fill="#fff" d="M38.96 50.52c-2.2 3.84-7.12 5.15-10.95 2.94-3.82-2.2-5.12-7.12-2.92-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.83 2.23 5.14 7.12 2.94 10.96"
-      style="transform: translate(100px, 100px);"></path>
-    <path class="iEGVWn" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M63.55 27.5l32.9 19-32.9-19z"></path>
-    <path class="bsocdx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96 46v38-38z"></path>
-    <path class="jAZXmP" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96.45 84.5l-32.9 19 32.9-19z"></path>
-    <path class="hSeArx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M64.45 103.5l-32.9-19 32.9 19z"></path>
-    <path class="bVgqGk" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M32 84V46v38z"></path>
-    <path class="hEFqBt" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M31.55 46.5l32.9-19-32.9 19z"></path>
-    <path class="dzEKCM" id="Triangle-Bottom" stroke="#fff" stroke-width="4" d="M30 84h70" stroke-linecap="round"></path>
-    <path class="DYnPx" id="Triangle-Left" stroke="#fff" stroke-width="4" d="M65 26L30 87" stroke-linecap="round"></path>
-    <path class="hjPEAQ" id="Triangle-Right" stroke="#fff" stroke-width="4" d="M98 87L63 26" stroke-linecap="round"></path>
-  </g>
-</svg>
-<div class="text">Loading
-  <span class="dGfHfc">GraphQL Playground</span>
-</div>
-</div>
-
-    <div id="root" />
-    <script type="text/javascript">
-      window.addEventListener('load', function (event) {
-        
-    const loadingWrapper = document.getElementById('loading-wrapper');
-    loadingWrapper.classList.add('fadeOut');
-    
-  
-        const root = document.getElementById('root');
-        root.classList.add('playgroundIn');
-  
-        GraphQLPlayground.init(root, {
-  "env": "react",
-  "canSaveConfig": false
-})
       })
-    </script>
-  </body>
-  </html>
+    })
+  </script>
+</body>
+
+</html>

--- a/packages/graphql-playground-react/src/__snapshots__/index.test.tsx.snap
+++ b/packages/graphql-playground-react/src/__snapshots__/index.test.tsx.snap
@@ -1,84 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test MiddleWareApp with tabs 1`] = `
+exports[`test MiddleWareApp passed default headers 1`] = `
 <div>
   <div
-    class="sc-bMVAic bUjTvZ"
+    class="sc-bAeIUo jscPmU"
   >
     <div
-      class="playground sc-gwVKww fjmhfX"
+      class="playground sc-hXRMBi caimge"
     >
       <div
-        class="sc-btzYZH gjuUJX"
+        class="sc-lhVmIH hMZGpR"
       >
         <div
-          class="sc-lhVmIH gceoJJ"
+          class="sc-bYSBpT cgxKmR"
         >
           <div
-            class="sc-gGBfsJ jzfwvs"
+            class="sc-jnlKLf eYHWGF"
           >
             <div
-              class="sc-tilXH eopbMp"
+              class="sc-hEsumM cXKFpX"
             >
               <div
-                class="sc-hEsumM imgWrU"
+                class="sc-ktHwxA loQVQX"
               />
             </div>
             <div
-              class="sc-jnlKLf lcOfJK"
+              class="sc-fYxtnH fzgrEl"
             >
               New Tab
             </div>
             <div
-              class="close sc-jwKygS kXXdpA"
+              class="close sc-btzYZH cttKsG"
             />
           </div>
           <div
-            class="sc-bYSBpT ikmtjk"
+            class="sc-elJkPf jYmNRN"
           />
         </div>
       </div>
       <div
-        class="graphiqls-container sc-hXRMBi cmqJEq"
+        class="graphiqls-container sc-epnACN kltGk"
       >
         <div
-          class="graphiql-wrapper active sc-epnACN fjUyqz"
+          class="graphiql-wrapper active sc-iQNlJl kEHQIY"
         >
           <div
-            class="sc-ifAKCX hSorDx"
+            class="sc-EHOje cIypmL"
           >
             <div
-              class="sc-bxivhb cSHbqu"
+              class="sc-ifAKCX fjtMTo"
             >
               <div
-                class="sc-fBuWsC ZNWmR"
+                class="sc-fMiknA eacLCC"
               >
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   Prettify
                 </button>
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   History
                 </button>
                 <div
-                  class="sc-dVhcbM empwHB"
+                  class="sc-eqIVtm cgwgzU"
                 >
                   <input
-                    class="sc-fMiknA jxOjZz"
+                    class="sc-dVhcbM jTygPs"
                     value="about:blank"
                   />
                   <div
-                    class="sc-csuQGl WHwwm"
+                    class="sc-Rmtcm kkUIDC"
                   >
                     <svg
-                      class="sc-Rmtcm gMicmQ"
+                      class="sc-bRBYWo linmmw"
                       viewBox="0 0 20 20"
                     >
                       <circle
-                        class="sc-bRBYWo fJBPZy"
+                        class="sc-hzDkRC jSRGuu"
                         cx="9.5"
                         cy="10"
                         fill="none"
@@ -87,26 +87,26 @@ exports[`test MiddleWareApp with tabs 1`] = `
                         stroke-width="1.5"
                       />
                       <path
-                        class="sc-hzDkRC kwVHNl"
+                        class="sc-jhAzac NPpIa"
                         d="M4.83 4.86a6.92 6.92 0 0 1 11.3 2.97l.41-1.23c.13-.4.56-.6.95-.47.4.13.6.56.47.95l-1.13 3.33a.76.76 0 0 1-.7.5.72.72 0 0 1-.43-.12l-2.88-1.92a.76.76 0 0 1-.2-1.04.75.75 0 0 1 1.03-.2l1.06.7A5.34 5.34 0 0 0 9.75 4.5a5.44 5.44 0 0 0-5.64 5.22 5.42 5.42 0 0 0 5.24 5.62c.41 0 .74.36.72.78a.75.75 0 0 1-.75.72H9.3a6.9 6.9 0 0 1-6.68-7.18 6.88 6.88 0 0 1 2.22-4.81z"
                       />
                     </svg>
                   </div>
                 </div>
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   Copy CURL
                 </button>
                 <div
-                  class="sc-cMljjf UdVJG"
+                  class="sc-jAaTju izqnJQ"
                 >
                   <div
-                    class="sc-jDwBTQ jzYUAi"
+                    class="sc-gPEVay hZVzor"
                   >
                     <div>
                       <button
-                        class="sc-jhAzac iQTNgc"
+                        class="sc-fBuWsC fLszzQ"
                       >
                         Share Playground
                       </button>
@@ -115,49 +115,49 @@ exports[`test MiddleWareApp with tabs 1`] = `
                 </div>
               </div>
               <div
-                class="sc-kjoXOD gqoYfp"
+                class="sc-cHGsZl gXxfHh"
               >
                 <div
-                  class="sc-jqCOkK Xczwm"
+                  class="sc-uJMKN keNgMU"
                 >
                   <div
-                    class="sc-bxivhb cSHbqu"
+                    class="sc-ifAKCX fjtMTo"
                   >
                     <div
-                      class="sc-EHOje cFfLgL"
+                      class="sc-bZQynM gulWsJ"
                     />
                   </div>
                   <div
-                    class="sc-frDJqD gltkeK sc-ksYbfQ dvtHmk"
+                    class="sc-kvZOFW kEeHPI sc-hmzhuo hJPwxf"
                     height="200"
                   >
                     <div
-                      class="sc-kvZOFW ishkgm sc-hmzhuo jlrOeJ"
+                      class="sc-hqyNC iVUKVr sc-frDJqD bjpSmb"
                     >
                       <span
-                        class="sc-hqyNC cpGMZo"
+                        class="sc-jbKcbu crrjpn"
                       >
                         Query Variables
                       </span>
                       <span
-                        class="sc-hqyNC jQhkci"
+                        class="sc-jbKcbu cUoSJz"
                       >
-                        HTTP Headers 
+                        HTTP Headers (1)
                       </span>
                     </div>
                     <div
-                      class="sc-gisBJw eBRpMn"
+                      class="sc-kjoXOD djmrSS"
                     />
                   </div>
                   <div
-                    class="sc-kgAjT frYSpF sc-TOsTZ dPEkXa"
+                    class="sc-cJSrbW cdFwbg sc-kgAjT hfRSWa"
                   />
                 </div>
                 <div
-                  class="sc-cHGsZl eSKmpv"
+                  class="sc-TOsTZ GvCtl"
                 >
                   <div
-                    class="sc-cJSrbW epemlL sc-TOsTZ dPEkXa"
+                    class="sc-ksYbfQ hvCXwe sc-kgAjT hfRSWa"
                   />
                   <div
                     class="sc-bdVaJa bFURGJ"
@@ -178,39 +178,43 @@ exports[`test MiddleWareApp with tabs 1`] = `
                     </div>
                   </div>
                   <div
-                    class="sc-dnqmqq glHaJN"
+                    class="sc-iwsKbI cRrmDs"
                   >
                     <div
-                      class="sc-iwsKbI eLjmCv"
+                      class="sc-gZMcBi ruAOc"
                     >
                       <div
-                        class="sc-VigVT gJoWAv"
+                        class="sc-jTzLTM dWZjO"
                       >
                         <div
-                          class="sc-htoDjs iWZbiD"
+                          class="sc-dnqmqq hqaUtI"
                         />
                       </div>
                     </div>
                   </div>
                   <div
-                    class="sc-uJMKN gpVNBQ"
+                    class="sc-bbmXgH kEppjG"
                   >
                     Hit the Play Button to get a response here
                   </div>
                   <div
-                    class="sc-jbKcbu jkOLOQ sc-ksYbfQ dvtHmk"
+                    class="sc-dNLxif dRzCeo sc-hmzhuo hJPwxf"
                     height="300"
                   >
                     <div
-                      class="sc-dNLxif hpHnat sc-hmzhuo jlrOeJ"
+                      class="sc-jqCOkK kXpZpy sc-frDJqD bjpSmb"
                     >
-                      Tracing
+                      <span
+                        class="sc-jbKcbu crrjpn"
+                      >
+                        Tracing
+                      </span>
                     </div>
                     <div
-                      class="sc-chPdSV egsZhV"
+                      class="sc-kgoBCf dBQkwa"
                     >
                       <div
-                        class="sc-kGXeez zSNfc"
+                        class="sc-kpOJdX cREUIk"
                       >
                         This GraphQL server doesn’t support tracing. See the following page for instructions:
                         <br />
@@ -222,7 +226,7 @@ exports[`test MiddleWareApp with tabs 1`] = `
               </div>
             </div>
             <div
-              class="graph-docs docExplorerWrap docs sc-ckVGcZ gTAROz"
+              class="graph-docs docExplorerWrap docs sc-jKJlTe kXYhbp"
               style="width:0"
             >
               <div
@@ -231,13 +235,13 @@ exports[`test MiddleWareApp with tabs 1`] = `
                 Schema
               </div>
               <div
-                class="sc-eNQAEJ bnCHKQ"
+                class="sc-hMqMXs jdpLqQ"
               />
               <div
                 class="doc-explorer-gradient"
               />
               <div
-                class="sc-jKJlTe iEsLJA"
+                class="sc-eNQAEJ jXONrf"
                 tabindex="0"
               >
                 <div
@@ -248,10 +252,10 @@ exports[`test MiddleWareApp with tabs 1`] = `
                     style="width:300px"
                   >
                     <div
-                      class="sc-bZQynM kkBsVS"
+                      class="sc-gzVnrw fNvFrw"
                     >
                       <div
-                        class="sc-gzVnrw fwQvxW"
+                        class="sc-htoDjs kgEMPg"
                       />
                     </div>
                   </div>
@@ -262,10 +266,287 @@ exports[`test MiddleWareApp with tabs 1`] = `
         </div>
       </div>
       <div
-        class="sc-kIPQKe dFoBip"
+        class="sc-eXEjpC cltmBE"
       >
         <div
-          class="sc-eXEjpC ixbGWH"
+          class="sc-ibxdXY kyOYfW"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`test MiddleWareApp with tabs 1`] = `
+<div>
+  <div
+    class="sc-bAeIUo jscPmU"
+  >
+    <div
+      class="playground sc-hXRMBi caimge"
+    >
+      <div
+        class="sc-lhVmIH hMZGpR"
+      >
+        <div
+          class="sc-bYSBpT cgxKmR"
+        >
+          <div
+            class="sc-jnlKLf eYHWGF"
+          >
+            <div
+              class="sc-hEsumM cXKFpX"
+            >
+              <div
+                class="sc-ktHwxA loQVQX"
+              />
+            </div>
+            <div
+              class="sc-fYxtnH fzgrEl"
+            >
+              New Tab
+            </div>
+            <div
+              class="close sc-btzYZH cttKsG"
+            />
+          </div>
+          <div
+            class="sc-elJkPf jYmNRN"
+          />
+        </div>
+      </div>
+      <div
+        class="graphiqls-container sc-epnACN kltGk"
+      >
+        <div
+          class="graphiql-wrapper active sc-iQNlJl kEHQIY"
+        >
+          <div
+            class="sc-EHOje cIypmL"
+          >
+            <div
+              class="sc-ifAKCX fjtMTo"
+            >
+              <div
+                class="sc-fMiknA eacLCC"
+              >
+                <button
+                  class="sc-fBuWsC fLszzQ"
+                >
+                  Prettify
+                </button>
+                <button
+                  class="sc-fBuWsC fLszzQ"
+                >
+                  History
+                </button>
+                <div
+                  class="sc-eqIVtm cgwgzU"
+                >
+                  <input
+                    class="sc-dVhcbM jTygPs"
+                    value="about:blank"
+                  />
+                  <div
+                    class="sc-Rmtcm kkUIDC"
+                  >
+                    <svg
+                      class="sc-bRBYWo linmmw"
+                      viewBox="0 0 20 20"
+                    >
+                      <circle
+                        class="sc-hzDkRC jSRGuu"
+                        cx="9.5"
+                        cy="10"
+                        fill="none"
+                        r="6"
+                        stroke-linecap="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        class="sc-jhAzac NPpIa"
+                        d="M4.83 4.86a6.92 6.92 0 0 1 11.3 2.97l.41-1.23c.13-.4.56-.6.95-.47.4.13.6.56.47.95l-1.13 3.33a.76.76 0 0 1-.7.5.72.72 0 0 1-.43-.12l-2.88-1.92a.76.76 0 0 1-.2-1.04.75.75 0 0 1 1.03-.2l1.06.7A5.34 5.34 0 0 0 9.75 4.5a5.44 5.44 0 0 0-5.64 5.22 5.42 5.42 0 0 0 5.24 5.62c.41 0 .74.36.72.78a.75.75 0 0 1-.75.72H9.3a6.9 6.9 0 0 1-6.68-7.18 6.88 6.88 0 0 1 2.22-4.81z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <button
+                  class="sc-fBuWsC fLszzQ"
+                >
+                  Copy CURL
+                </button>
+                <div
+                  class="sc-jAaTju izqnJQ"
+                >
+                  <div
+                    class="sc-gPEVay hZVzor"
+                  >
+                    <div>
+                      <button
+                        class="sc-fBuWsC fLszzQ"
+                      >
+                        Share Playground
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="sc-cHGsZl gXxfHh"
+              >
+                <div
+                  class="sc-uJMKN keNgMU"
+                >
+                  <div
+                    class="sc-ifAKCX fjtMTo"
+                  >
+                    <div
+                      class="sc-bZQynM gulWsJ"
+                    />
+                  </div>
+                  <div
+                    class="sc-kvZOFW kEeHPI sc-hmzhuo hJPwxf"
+                    height="200"
+                  >
+                    <div
+                      class="sc-hqyNC iVUKVr sc-frDJqD bjpSmb"
+                    >
+                      <span
+                        class="sc-jbKcbu crrjpn"
+                      >
+                        Query Variables
+                      </span>
+                      <span
+                        class="sc-jbKcbu cUoSJz"
+                      >
+                        HTTP Headers 
+                      </span>
+                    </div>
+                    <div
+                      class="sc-kjoXOD djmrSS"
+                    />
+                  </div>
+                  <div
+                    class="sc-cJSrbW cdFwbg sc-kgAjT hfRSWa"
+                  />
+                </div>
+                <div
+                  class="sc-TOsTZ GvCtl"
+                >
+                  <div
+                    class="sc-ksYbfQ hvCXwe sc-kgAjT hfRSWa"
+                  />
+                  <div
+                    class="sc-bdVaJa bFURGJ"
+                  >
+                    <div
+                      class="sc-bwzfXH iNzYbQ"
+                      title="Execute Query (Ctrl-Enter)"
+                    >
+                      <svg
+                        height="35"
+                        viewBox="3.5,4.5,24,24"
+                        width="35"
+                      >
+                        <path
+                          d="M 11 9 L 24 16 L 11 23 z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="sc-iwsKbI cRrmDs"
+                  >
+                    <div
+                      class="sc-gZMcBi ruAOc"
+                    >
+                      <div
+                        class="sc-jTzLTM dWZjO"
+                      >
+                        <div
+                          class="sc-dnqmqq hqaUtI"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="sc-bbmXgH kEppjG"
+                  >
+                    Hit the Play Button to get a response here
+                  </div>
+                  <div
+                    class="sc-dNLxif dRzCeo sc-hmzhuo hJPwxf"
+                    height="300"
+                  >
+                    <div
+                      class="sc-jqCOkK kXpZpy sc-frDJqD bjpSmb"
+                    >
+                      <span
+                        class="sc-jbKcbu crrjpn"
+                      >
+                        Tracing
+                      </span>
+                    </div>
+                    <div
+                      class="sc-kgoBCf dBQkwa"
+                    >
+                      <div
+                        class="sc-kpOJdX cREUIk"
+                      >
+                        This GraphQL server doesn’t support tracing. See the following page for instructions:
+                        <br />
+                        https://github.com/apollographql/apollo-tracing
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="graph-docs docExplorerWrap docs sc-jKJlTe kXYhbp"
+              style="width:0"
+            >
+              <div
+                class="docs-button"
+              >
+                Schema
+              </div>
+              <div
+                class="sc-hMqMXs jdpLqQ"
+              />
+              <div
+                class="doc-explorer-gradient"
+              />
+              <div
+                class="sc-eNQAEJ jXONrf"
+                tabindex="0"
+              >
+                <div
+                  class="doc-explorer-container"
+                >
+                  <div
+                    class="graph-docs-column overflow"
+                    style="width:300px"
+                  >
+                    <div
+                      class="sc-gzVnrw fNvFrw"
+                    >
+                      <div
+                        class="sc-htoDjs kgEMPg"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-eXEjpC cltmBE"
+      >
+        <div
+          class="sc-ibxdXY kyOYfW"
         />
       </div>
     </div>
@@ -276,82 +557,82 @@ exports[`test MiddleWareApp with tabs 1`] = `
 exports[`test MiddleWareApp without tabs 1`] = `
 <div>
   <div
-    class="sc-bMVAic bUjTvZ"
+    class="sc-bAeIUo jscPmU"
   >
     <div
-      class="playground sc-gwVKww fjmhfX"
+      class="playground sc-hXRMBi caimge"
     >
       <div
-        class="sc-btzYZH gjuUJX"
+        class="sc-lhVmIH hMZGpR"
       >
         <div
-          class="sc-lhVmIH gceoJJ"
+          class="sc-bYSBpT cgxKmR"
         >
           <div
-            class="sc-gGBfsJ jzfwvs"
+            class="sc-jnlKLf eYHWGF"
           >
             <div
-              class="sc-tilXH eopbMp"
+              class="sc-hEsumM cXKFpX"
             >
               <div
-                class="sc-hEsumM imgWrU"
+                class="sc-ktHwxA loQVQX"
               />
             </div>
             <div
-              class="sc-jnlKLf lcOfJK"
+              class="sc-fYxtnH fzgrEl"
             >
               New Tab
             </div>
             <div
-              class="close sc-jwKygS kXXdpA"
+              class="close sc-btzYZH cttKsG"
             />
           </div>
           <div
-            class="sc-bYSBpT ikmtjk"
+            class="sc-elJkPf jYmNRN"
           />
         </div>
       </div>
       <div
-        class="graphiqls-container sc-hXRMBi cmqJEq"
+        class="graphiqls-container sc-epnACN kltGk"
       >
         <div
-          class="graphiql-wrapper active sc-epnACN fjUyqz"
+          class="graphiql-wrapper active sc-iQNlJl kEHQIY"
         >
           <div
-            class="sc-ifAKCX hSorDx"
+            class="sc-EHOje cIypmL"
           >
             <div
-              class="sc-bxivhb cSHbqu"
+              class="sc-ifAKCX fjtMTo"
             >
               <div
-                class="sc-fBuWsC ZNWmR"
+                class="sc-fMiknA eacLCC"
               >
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   Prettify
                 </button>
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   History
                 </button>
                 <div
-                  class="sc-dVhcbM empwHB"
+                  class="sc-eqIVtm cgwgzU"
                 >
                   <input
-                    class="sc-fMiknA jxOjZz"
+                    class="sc-dVhcbM jTygPs"
                     value="about:blank"
                   />
                   <div
-                    class="sc-csuQGl WHwwm"
+                    class="sc-Rmtcm kkUIDC"
                   >
                     <svg
-                      class="sc-Rmtcm gMicmQ"
+                      class="sc-bRBYWo linmmw"
                       viewBox="0 0 20 20"
                     >
                       <circle
-                        class="sc-bRBYWo fJBPZy"
+                        class="sc-hzDkRC jSRGuu"
                         cx="9.5"
                         cy="10"
                         fill="none"
@@ -360,26 +641,26 @@ exports[`test MiddleWareApp without tabs 1`] = `
                         stroke-width="1.5"
                       />
                       <path
-                        class="sc-hzDkRC kwVHNl"
+                        class="sc-jhAzac NPpIa"
                         d="M4.83 4.86a6.92 6.92 0 0 1 11.3 2.97l.41-1.23c.13-.4.56-.6.95-.47.4.13.6.56.47.95l-1.13 3.33a.76.76 0 0 1-.7.5.72.72 0 0 1-.43-.12l-2.88-1.92a.76.76 0 0 1-.2-1.04.75.75 0 0 1 1.03-.2l1.06.7A5.34 5.34 0 0 0 9.75 4.5a5.44 5.44 0 0 0-5.64 5.22 5.42 5.42 0 0 0 5.24 5.62c.41 0 .74.36.72.78a.75.75 0 0 1-.75.72H9.3a6.9 6.9 0 0 1-6.68-7.18 6.88 6.88 0 0 1 2.22-4.81z"
                       />
                     </svg>
                   </div>
                 </div>
                 <button
-                  class="sc-jhAzac iQTNgc"
+                  class="sc-fBuWsC fLszzQ"
                 >
                   Copy CURL
                 </button>
                 <div
-                  class="sc-cMljjf UdVJG"
+                  class="sc-jAaTju izqnJQ"
                 >
                   <div
-                    class="sc-jDwBTQ jzYUAi"
+                    class="sc-gPEVay hZVzor"
                   >
                     <div>
                       <button
-                        class="sc-jhAzac iQTNgc"
+                        class="sc-fBuWsC fLszzQ"
                       >
                         Share Playground
                       </button>
@@ -388,49 +669,49 @@ exports[`test MiddleWareApp without tabs 1`] = `
                 </div>
               </div>
               <div
-                class="sc-kjoXOD gqoYfp"
+                class="sc-cHGsZl gXxfHh"
               >
                 <div
-                  class="sc-jqCOkK Xczwm"
+                  class="sc-uJMKN keNgMU"
                 >
                   <div
-                    class="sc-bxivhb cSHbqu"
+                    class="sc-ifAKCX fjtMTo"
                   >
                     <div
-                      class="sc-EHOje cFfLgL"
+                      class="sc-bZQynM gulWsJ"
                     />
                   </div>
                   <div
-                    class="sc-frDJqD gltkeK sc-ksYbfQ dvtHmk"
+                    class="sc-kvZOFW kEeHPI sc-hmzhuo hJPwxf"
                     height="200"
                   >
                     <div
-                      class="sc-kvZOFW ishkgm sc-hmzhuo jlrOeJ"
+                      class="sc-hqyNC iVUKVr sc-frDJqD bjpSmb"
                     >
                       <span
-                        class="sc-hqyNC cpGMZo"
+                        class="sc-jbKcbu crrjpn"
                       >
                         Query Variables
                       </span>
                       <span
-                        class="sc-hqyNC jQhkci"
+                        class="sc-jbKcbu cUoSJz"
                       >
                         HTTP Headers 
                       </span>
                     </div>
                     <div
-                      class="sc-gisBJw eBRpMn"
+                      class="sc-kjoXOD djmrSS"
                     />
                   </div>
                   <div
-                    class="sc-kgAjT frYSpF sc-TOsTZ dPEkXa"
+                    class="sc-cJSrbW cdFwbg sc-kgAjT hfRSWa"
                   />
                 </div>
                 <div
-                  class="sc-cHGsZl eSKmpv"
+                  class="sc-TOsTZ GvCtl"
                 >
                   <div
-                    class="sc-cJSrbW epemlL sc-TOsTZ dPEkXa"
+                    class="sc-ksYbfQ hvCXwe sc-kgAjT hfRSWa"
                   />
                   <div
                     class="sc-bdVaJa bFURGJ"
@@ -451,39 +732,43 @@ exports[`test MiddleWareApp without tabs 1`] = `
                     </div>
                   </div>
                   <div
-                    class="sc-dnqmqq glHaJN"
+                    class="sc-iwsKbI cRrmDs"
                   >
                     <div
-                      class="sc-iwsKbI eLjmCv"
+                      class="sc-gZMcBi ruAOc"
                     >
                       <div
-                        class="sc-VigVT gJoWAv"
+                        class="sc-jTzLTM dWZjO"
                       >
                         <div
-                          class="sc-htoDjs iWZbiD"
+                          class="sc-dnqmqq hqaUtI"
                         />
                       </div>
                     </div>
                   </div>
                   <div
-                    class="sc-uJMKN gpVNBQ"
+                    class="sc-bbmXgH kEppjG"
                   >
                     Hit the Play Button to get a response here
                   </div>
                   <div
-                    class="sc-jbKcbu jkOLOQ sc-ksYbfQ dvtHmk"
+                    class="sc-dNLxif dRzCeo sc-hmzhuo hJPwxf"
                     height="300"
                   >
                     <div
-                      class="sc-dNLxif hpHnat sc-hmzhuo jlrOeJ"
+                      class="sc-jqCOkK kXpZpy sc-frDJqD bjpSmb"
                     >
-                      Tracing
+                      <span
+                        class="sc-jbKcbu crrjpn"
+                      >
+                        Tracing
+                      </span>
                     </div>
                     <div
-                      class="sc-chPdSV egsZhV"
+                      class="sc-kgoBCf dBQkwa"
                     >
                       <div
-                        class="sc-kGXeez zSNfc"
+                        class="sc-kpOJdX cREUIk"
                       >
                         This GraphQL server doesn’t support tracing. See the following page for instructions:
                         <br />
@@ -495,7 +780,7 @@ exports[`test MiddleWareApp without tabs 1`] = `
               </div>
             </div>
             <div
-              class="graph-docs docExplorerWrap docs sc-ckVGcZ gTAROz"
+              class="graph-docs docExplorerWrap docs sc-jKJlTe kXYhbp"
               style="width:0"
             >
               <div
@@ -504,13 +789,13 @@ exports[`test MiddleWareApp without tabs 1`] = `
                 Schema
               </div>
               <div
-                class="sc-eNQAEJ bnCHKQ"
+                class="sc-hMqMXs jdpLqQ"
               />
               <div
                 class="doc-explorer-gradient"
               />
               <div
-                class="sc-jKJlTe iEsLJA"
+                class="sc-eNQAEJ jXONrf"
                 tabindex="0"
               >
                 <div
@@ -521,10 +806,10 @@ exports[`test MiddleWareApp without tabs 1`] = `
                     style="width:300px"
                   >
                     <div
-                      class="sc-bZQynM kkBsVS"
+                      class="sc-gzVnrw fNvFrw"
                     >
                       <div
-                        class="sc-gzVnrw fwQvxW"
+                        class="sc-htoDjs kgEMPg"
                       />
                     </div>
                   </div>
@@ -535,10 +820,10 @@ exports[`test MiddleWareApp without tabs 1`] = `
         </div>
       </div>
       <div
-        class="sc-kIPQKe dFoBip"
+        class="sc-eXEjpC cltmBE"
       >
         <div
-          class="sc-eXEjpC ixbGWH"
+          class="sc-ibxdXY kyOYfW"
         />
       </div>
     </div>

--- a/packages/graphql-playground-react/src/components/GraphQLBinApp.tsx
+++ b/packages/graphql-playground-react/src/components/GraphQLBinApp.tsx
@@ -26,6 +26,7 @@ export interface Props {
   subscriptionEndpoint?: string
   history?: any
   match?: any
+  headers?: any
 }
 
 export interface State {
@@ -33,6 +34,7 @@ export interface State {
   subscriptionEndpoint?: string
   shareUrl?: string
   loading: boolean
+  headers: any
 }
 
 export interface ReduxProps {
@@ -47,6 +49,7 @@ class GraphQLBinApp extends React.Component<Props & ReduxProps, State> {
       endpoint: props.endpoint,
       subscriptionEndpoint: props.subscriptionEndpoint,
       loading: false,
+      headers: props.headers || {},
     }
   }
 
@@ -140,6 +143,7 @@ class GraphQLBinApp extends React.Component<Props & ReduxProps, State> {
         ) : (
           <PlaygroundWrapper
             endpoint={endpoint}
+            headers={this.state.headers}
             subscriptionEndpoint={subscriptionEndpoint}
           />
         )}

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -62,6 +62,7 @@ export interface PlaygroundWrapperProps {
   schema?: { __schema: any } // introspection result
   codeTheme?: EditorColours
   workspaceName?: string
+  headers?: any
 }
 
 export interface ReduxProps {
@@ -334,6 +335,10 @@ class PlaygroundWrapper extends React.Component<
       </Helmet>
     ) : null
 
+    const defaultHeaders = this.props.headers || {}
+    const stateHeaders = this.state.headers || {}
+    const combinedHeaders = { ...defaultHeaders, ...stateHeaders }
+
     const { theme } = this.props
     return (
       <div>
@@ -385,7 +390,7 @@ class PlaygroundWrapper extends React.Component<
                 onSaveConfig={this.handleSaveConfig}
                 onUpdateSessionCount={this.handleUpdateSessionCount}
                 fixedEndpoints={Boolean(this.state.configString)}
-                headers={this.state.headers}
+                headers={combinedHeaders}
                 configPath={this.props.configPath}
                 workspaceName={
                   this.props.workspaceName || this.state.activeProjectName

--- a/packages/graphql-playground-react/src/index.test.tsx
+++ b/packages/graphql-playground-react/src/index.test.tsx
@@ -56,3 +56,14 @@ test('test MiddleWareApp with one tab and click execute', () => {
   const executeButton = wrapper.wrap(executeButtonElement)
   expect(executeButton.length).toBe(1)
 })
+
+test('test MiddleWareApp passed default headers', () => {
+  const wrapper = render(
+    <MiddlewareApp
+      setTitle={true}
+      showNewWorkspace={false}
+      headers={{ test: 'test' }}
+    />,
+  )
+  expect(wrapper).toMatchSnapshot()
+})


### PR DESCRIPTION
Feature implementation for #636 .

Changes proposed in this pull request:

- Add `headers` option to `GraphQLPlayground.init()`
- Add `headers` property to `GraphQLBinApp` and pass it through to `PlaygroundWrapper`
- Combine endpoint headers and default headers when passing through to `Playground`


## Adding a "test" header like this;
![image](https://user-images.githubusercontent.com/16615089/44661691-057ae800-a9d1-11e8-92cb-141ed600e623.png)
## results in:
![image](https://user-images.githubusercontent.com/16615089/44661736-322eff80-a9d1-11e8-93a0-8f9647765532.png)
