### PR TITLE
Fix MiddlewareApp never properly applying settings passed as props.

### DIFF
--- a/packages/graphql-playground-react/src/components/MiddlewareApp.tsx
+++ b/packages/graphql-playground-react/src/components/MiddlewareApp.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import createStore from '../state/createStore'
+import { getSettings } from '../state/workspace/reducers'
+import { setSettingsString } from '../state/general/actions'
 import PlaygroundWrapper, { PlaygroundWrapperProps } from './PlaygroundWrapper'
 
 const store = createStore()
@@ -8,6 +10,12 @@ const store = createStore()
 export default class MiddlewareApp extends React.Component<
   PlaygroundWrapperProps
 > {
+  componentDidMount() {
+    const initialSettings = getSettings(store.getState())
+    const mergedSettings = { ...initialSettings, ...this.props.settings }
+    const settingsString = JSON.stringify(mergedSettings, null, 2)
+    store.dispatch(setSettingsString(settingsString))
+  }
   render() {
     return (
       <Provider store={store}>

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -522,7 +522,7 @@ class PlaygroundWrapper extends React.Component<
 
 const mapStateToProps = (state, ownProps) => {
   const theme = ownProps.theme || getTheme(state, ownProps.settings)
-  const settings = ownProps.settings || getSettings(state)
+  const settings = getSettings(state)
   return { theme, settings }
 }
 


### PR DESCRIPTION
Fixes #826, #796, #791, #790, etc..

Basically, the MiddlewareApp component was never actually applying the settings it was passed. I think https://github.com/prisma/graphql-playground/pull/759 was an attempted fix, but as PlaygroundWrapper doesn't actually pass settings to the Playground, all this meant was that the ThemeProvider component would take the settings applied over ones from redux. (Not merging them). This caused the weird hidden cursor bug, as if you didn't explicitly set the cursor but did set other options, you lost your cursor. This changes means the settings should be merged correctly into the redux state, and the PlaygroundWrapper app can just take the settings from the state as it should.