### PR TITLE
renderPlaygroundPage - cdnUrl config option

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -54,6 +54,7 @@ export interface IntrospectionResult {
 
 export interface RenderPageOptions extends MiddlewareOptions {
   version: string
+  cdnUrl?: string
   env?: any
 }
 
@@ -67,15 +68,15 @@ export interface Tab {
 
 const loading = getLoadingMarkup()
 
-const getCdnMarkup = options => `
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@${
-      options.version
+const getCdnMarkup = ({version, cdnUrl = '//cdn.jsdelivr.net/npm'}) => `
+    <link rel="stylesheet" href="${cdnUrl}/graphql-playground-react@${
+      version
     }/build/static/css/index.css" />
-    <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@${
-      options.version
+    <link rel="shortcut icon" href="${cdnUrl}/graphql-playground-react@${
+      version
     }/build/favicon.png" />
-    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@${
-      options.version
+    <script src="${cdnUrl}/graphql-playground-react@${
+      version
     }/build/static/js/middleware.js"></script>
 `
 

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -69,14 +69,14 @@ export interface Tab {
 const loading = getLoadingMarkup()
 
 const getCdnMarkup = ({version, cdnUrl = '//cdn.jsdelivr.net/npm'}) => `
-    <link rel="stylesheet" href="${cdnUrl}/graphql-playground-react@${
-      version
+    <link rel="stylesheet" href="${cdnUrl}/graphql-playground-react${
+      version ? `@${version}` : ''
     }/build/static/css/index.css" />
-    <link rel="shortcut icon" href="${cdnUrl}/graphql-playground-react@${
-      version
+    <link rel="shortcut icon" href="${cdnUrl}/graphql-playground-react${
+      version ? `@${version}` : ''
     }/build/favicon.png" />
-    <script src="${cdnUrl}/graphql-playground-react@${
-      version
+    <script src="${cdnUrl}/graphql-playground-react${
+      version ? `@${version}` : ''
     }/build/static/js/middleware.js"></script>
 `
 


### PR DESCRIPTION
Allow the cdn url to be passed in to renderPlaygroundPage as an option. This is to support graphql-playground being used offline by tools such as Apollo Server. See https://github.com/apollographql/apollo-server/issues/1421
