### PR TITLE
Fix warning about uncontrolled input

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/Tab.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/Tab.tsx
@@ -66,7 +66,7 @@ class Tab extends React.PureComponent<Props & ReduxProps, State> {
         </Icons>
         {this.state.editingName ? (
           <OperationNameInput
-            value={session.name}
+            value={session.name || ''}
             onChange={this.handleEditName}
             onBlur={this.stopEditName}
             onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
A new session's name will initially be `undefined`, so I ensured that the value we pass to the input will always be a string.  This fixes the React warning `Warning: A component is changing an uncontrolled input of type undefined to be controlled` that was appearing when you rename a tab.