### PR TITLE
Adding tooltips to buttons without text (#347)

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/Tab.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/Tab.tsx
@@ -94,6 +94,7 @@ class Tab extends React.PureComponent<Props & ReduxProps, State> {
               width={12}
               height={11}
               strokeWidth={7}
+              title="Close tab"
             />
           )}
         </Close>

--- a/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
@@ -42,6 +42,7 @@ const TabBar = ({
           height={34}
           stroke={true}
           strokeWidth={4}
+          title="Opens a New Tab"
         />
       </Plus>
     </Tabs>

--- a/packages/graphql-playground-react/src/components/Playground/TopBar/ReloadIcon.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/ReloadIcon.tsx
@@ -7,7 +7,7 @@ export interface Props {
 }
 
 const ReloadIcon: React.SFC<Props> = props => (
-  <Positioner onClick={props.onReloadSchema}>
+  <Positioner onClick={props.onReloadSchema} title="Reload Schema">
     <Svg viewBox="0 0 20 20">
       <Circle
         cx="9.5"

--- a/packages/graphql-playground-react/src/components/Settings.tsx
+++ b/packages/graphql-playground-react/src/components/Settings.tsx
@@ -19,6 +19,7 @@ class Settings extends React.Component<Props, {}> {
             height={23}
             onClick={this.props.onClick}
             className={'settings-icon'}
+            title="Settings"
           />
         </IconWrapper>
       </Wrapper>

--- a/packages/graphql-playground-react/src/components/Share.tsx
+++ b/packages/graphql-playground-react/src/components/Share.tsx
@@ -105,6 +105,7 @@ class Share extends React.Component<SharingProps, State> {
                             color={$v.darkBlue30}
                             width={25}
                             height={25}
+                            title="Copy URL to Clipboard"
                           />
                         </Copy>
                       </CopyWrapper>


### PR DESCRIPTION
Fixes #347.

Changes proposed in this pull request:

- Added "title" to icon buttons missing tooltips

Let me know if I missed out on anything.