### PR TITLE
Use query definition name as firstOperationName if any

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/util/getQueryTypes.ts
+++ b/packages/graphql-playground-react/src/components/Playground/util/getQueryTypes.ts
@@ -10,6 +10,10 @@ export const getQueryTypes = (ast): QueryTypes => {
   if (ast && ast.definitions) {
     ast.definitions.forEach(definition => {
       if (!firstOperationName) {
+        firstOperationName = definition.name && definition.name.value
+      }
+
+      if (!firstOperationName) {
         firstOperationName =
           definition.selectionSet &&
           definition.selectionSet.selections &&


### PR DESCRIPTION
Changes proposed in this pull request:

- This change allows to use queries/mutations [operation name](https://graphql.org/learn/queries/#operation-name) as `firstOperationName` value.

