### PR TITLE
Fix lint tooltip background to be infobackground (#832)

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/EditorWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/EditorWrapper.tsx
@@ -670,7 +670,7 @@ const GlobalStyle = createGlobalStyle`
 
 
   .CodeMirror-lint-tooltip, .CodeMirror-info {
-    background-color: white;
+    background-color: infobackground;
     border-radius: 4px 4px 4px 4px;
     border: 1px solid black;
     color: infotext;


### PR DESCRIPTION
Fixes #832.

As noted in the issue the lint tooltip text has not been visible in Firefox. This is due to the use of `color: infotext` with `background-color: white`. `color: infotext` is a browser dependent color that is black in Chrome but white in Firefox. [Per MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#System_Colors) `color: infotext` should be paired with `background-color: infobackground` as I have done in this pull request. 

Note that this changes the tooltip style in Chrome as well.

Changes proposed in this pull request:

- Change the lint tooltip background-color to infobackground

**In Firefox**:
Before:
![Before](https://user-images.githubusercontent.com/911786/47308648-3017a480-d600-11e8-8d12-863a69ab737b.png)
After:
![After](https://user-images.githubusercontent.com/911786/47308588-03fc2380-d600-11e8-87a0-b38b61b54e92.png)

**In Chrome:**
Before:
![Before](https://user-images.githubusercontent.com/911786/47308750-85ec4c80-d600-11e8-8fb9-bccd05441088.png)
After:
![After](https://user-images.githubusercontent.com/911786/47310132-37d94800-d604-11e8-9f8a-535e01a56950.png)
