### PR TITLE
README updates

### DIFF
--- a/packages/graphql-playground-middleware-express/README.md
+++ b/packages/graphql-playground-middleware-express/README.md
@@ -1,0 +1,29 @@
+# graphql-playground-middleware-express
+> Express middleware to expose an endpoint for the GraphQL Playground IDE
+
+## Installation
+
+Using yarn:
+
+```console
+yarn add graphql-playground-middleware-express
+```
+
+Or npm:
+
+```console
+npm install graphql-playground-middleware-express --save
+```
+
+## Usage
+
+See full example in [examples/basic](https://github.com/prisma/graphql-playground/tree/master/packages/graphql-playground-middleware-express/examples/basic).
+
+```js
+const express = require('express')
+const expressPlayground = require('graphql-playground-middleware-express')
+
+const app = express()
+
+app.get('/playground', expressPlayground({ endpoint: '/graphql' }))
+```

--- a/packages/graphql-playground-middleware-koa/README.md
+++ b/packages/graphql-playground-middleware-koa/README.md
@@ -1,0 +1,31 @@
+# graphql-playground-middleware-koa
+> Koa middleware to expose an endpoint for the GraphQL Playground IDE
+
+## Installation
+
+Using yarn:
+
+```console
+yarn add graphql-playground-middleware-koa
+```
+
+Or npm:
+
+```console
+npm install graphql-playground-middleware-koa --save
+```
+
+## Usage
+
+See full example in [examples/basic](https://github.com/prisma/graphql-playground/tree/master/packages/graphql-playground-middleware-koa/examples/basic).
+
+```js
+const koa = require('koa')
+const koaRouter = require('koa-router')
+const koaPlayground = require('graphql-playground-middleware-koa')
+
+const app = new koa()
+const router = new koaRouter()
+
+router.all('/playground', koaPlayground({ endpoint: '/graphql' }))
+```

--- a/packages/graphql-playground-react/README.md
+++ b/packages/graphql-playground-react/README.md
@@ -30,7 +30,7 @@ See the following question for more additonal features.
 
 The desktop app is the same as the web version but includes these additional features:
 
-- Support for [graphql-config](https://github.com/graphcool/graphql-config) enabling features like multi-environment setups.
+- Support for [graphql-config](https://github.com/prisma/graphql-config) enabling features like multi-environment setups.
 - Double click on `*.graphql` files.
 
 ### How does GraphQL Bin work?
@@ -39,7 +39,7 @@ You can easily share your Playgrounds with others by clicking on the "Share" but
 
 ![](https://imgur.com/H1n64lL.png)
 
-> You can also find the announcement blog post [here](https://blog.graph.cool/introducing-graphql-playground-f1e0a018f05d).
+> You can also find the announcement blog post [here](https://www.prisma.io/blog/introducing-graphql-playground-f1e0a018f05d).
 
 ## Usage
 
@@ -105,11 +105,11 @@ yarn add graphql-playground-middleware-lambda
 
 We have a full example for each of the frameworks below:
 
-- **Express:** See [packages/graphql-playground-middleware-express/examples/basic](https://github.com/graphcool/graphql-playground/tree/master/packages/graphql-playground-middleware-express/examples/basic)
+- **Express:** See [packages/graphql-playground-middleware-express/examples/basic](https://github.com/prisma/graphql-playground/tree/master/packages/graphql-playground-middleware-express/examples/basic)
 
-- **Hapi:** See [packages/graphql-playground-middleware/examples/hapi](https://github.com/graphcool/graphql-playground/tree/master/packages/graphql-playground-middleware/examples/hapi)
+- **Hapi:** See [packages/graphql-playground-middleware/examples/hapi](https://github.com/prisma/graphql-playground/tree/master/packages/graphql-playground-middleware-hapi/examples/basic)
 
-- **Koa:** See [packages/graphql-playground-middleware/examples/koa](https://github.com/graphcool/graphql-playground/tree/master/packages/graphql-playground-middleware/examples/koa)
+- **Koa:** See [packages/graphql-playground-middleware/examples/koa](https://github.com/prisma/graphql-playground/tree/master/packages/graphql-playground-middleware-koa/examples/basic)
 
 - **Lambda (as serverless handler):** See [serverless-graphql-apollo](https://github.com/serverless/serverless-graphql-apollo) or a quick example below.
 


### PR DESCRIPTION
Fixes #719.

Changes proposed in this pull request:

* Add a basic README for `graphql-playground-middleware-express`
* Add a basic README for `graphql-playground-middleware-koa`
* Update renamed/broken links in `graphql-playground-react` README
