### PR TITLE
fix: do not throw error when server response with empty array errors

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
+++ b/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
@@ -71,7 +71,7 @@ export class SchemaFetcher {
     return new Promise((resolve, reject) => {
       execute(link, operation).subscribe({
         next: schemaData => {
-          if (schemaData && (schemaData.errors || !schemaData.data)) {
+          if (schemaData && ((schemaData.errors && schemaData.errors.length > 0) || !schemaData.data)) {
             throw new Error(JSON.stringify(schemaData, null, 2))
           }
 


### PR DESCRIPTION
Fixes https://github.com/prisma/graphql-playground/issues/864.

Changes proposed in this pull request:

- Address empty array errors as no errors