### PR TITLE
Fix overflow docs in electron app

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/ColumnDoc.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/ColumnDoc.tsx
@@ -32,5 +32,6 @@ const Column = styled<ColumnProps, 'div'>('div')`
   flex-flow: column;
   padding-bottom: 20px;
   border-right: 1px solid ${p => p.theme.colours.black10};
-  overflow: ${p => (p.overflow ? 'hidden scroll' : 'auto auto')};
+  overflow-x: ${p => (p.overflow ? 'hidden' : 'auto')}
+  overflow-y: ${p => (p.overflow ? 'scroll' : 'auto')}
 `


### PR DESCRIPTION
Fixes #885 

Changes proposed in this pull request:

- Change overflow styling in PlayGround/DocExplorer/ColumnDoc to explicitly set overflow-x and overflow-y styling. The overflow works on the browser version of the app, but for some reason, the Electron app version does not respect the `overflow` property with two arguments. Replacing this with the overflow-x and overflow-y properties with single arguments leads to the appropriate styling in all apps.