### PR TITLE
Changed property name to remove warning

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/ColumnDoc.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/ColumnDoc.tsx
@@ -14,7 +14,7 @@ const ColumnDoc = ({
   width = columnWidth,
 }: Props) => {
   return (
-    <Column style={{ width }} overflow={overflow}>
+    <Column style={{ width }} verticalScroll={overflow}>
       {children}
     </Column>
   )
@@ -23,7 +23,7 @@ const ColumnDoc = ({
 export default ColumnDoc
 
 interface ColumnProps {
-  overflow: boolean
+  verticalScroll: boolean
 }
 
 const Column = styled<ColumnProps, 'div'>('div')`
@@ -32,6 +32,6 @@ const Column = styled<ColumnProps, 'div'>('div')`
   flex-flow: column;
   padding-bottom: 20px;
   border-right: 1px solid ${p => p.theme.colours.black10};
-  overflow-x: ${p => (p.overflow ? 'hidden' : 'auto')}
-  overflow-y: ${p => (p.overflow ? 'scroll' : 'auto')}
+  overflow-x: ${p => (p.verticalScroll ? 'hidden' : 'auto')}
+  overflow-y: ${p => (p.verticalScroll ? 'scroll' : 'auto')}
 `


### PR DESCRIPTION
Some issue with styled-components is causing warning message

Fixes #894 

Changes proposed in this pull request:

- Changing property name 
