### PR TITLE
Responsiveness across the main editor (#620)

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExecuteButton.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExecuteButton.tsx
@@ -198,6 +198,11 @@ const Wrapper = styled.div`
   z-index: 5;
   top: 15px;
   margin: 0 14px 0 28px;
+  @media screen and (max-width: 767px) {
+    top: -37px;
+    left: 50%;
+    margin: 0 0 0 -36px;
+  }
 `
 
 interface ButtonProps {

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -603,6 +603,9 @@ connect<any, any, any>(
 const EditorBar = styled.div`
   display: flex;
   flex-direction: row;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+  }
   flex: 1;
 `
 

--- a/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
@@ -36,7 +36,11 @@ export interface Props {
   refetchSchema: () => void
 }
 
-class TopBar extends React.Component<Props, {}> {
+interface State {
+  showMobileMenu: boolean
+}
+
+class TopBar extends React.Component<Props, State> {
   static contextTypes = {
     store: PropTypes.shape({
       subscribe: PropTypes.func.isRequired,
@@ -44,45 +48,65 @@ class TopBar extends React.Component<Props, {}> {
       getState: PropTypes.func.isRequired,
     }),
   }
+  state = { showMobileMenu: false }
   render() {
     const { endpointUnreachable } = this.props
     return (
       <TopBarWrapper>
-        <Button onClick={this.props.prettifyQuery}>Prettify</Button>
-        <Button onClick={this.openHistory}>History</Button>
-        <UrlBarWrapper>
-          <UrlBar
-            value={this.props.endpoint}
-            onChange={this.onChange}
-            onKeyDown={this.onKeyDown}
-            onBlur={this.props.refetchSchema}
-            disabled={this.props.fixedEndpoint}
-            active={!this.props.fixedEndpoint}
-          />
-          {endpointUnreachable ? (
-            <ReachError>
-              <span>Server cannot be reached</span>
-              <Spinner />
-            </ReachError>
-          ) : (
-            <ReloadIcon
-              isReloadingSchema={this.props.isReloadingSchema}
-              onReloadSchema={this.props.refetchSchema}
+        <TopBarInnerWrapper>
+          <Button desktopOnly={true} onClick={this.props.prettifyQuery}>
+            Prettify
+          </Button>
+          <Button desktopOnly={true} onClick={this.openHistory}>
+            History
+          </Button>
+          <UrlBarWrapper>
+            <UrlBar
+              value={this.props.endpoint}
+              onChange={this.onChange}
+              onKeyDown={this.onKeyDown}
+              onBlur={this.props.refetchSchema}
+              disabled={this.props.fixedEndpoint}
+              active={!this.props.fixedEndpoint}
             />
+            {endpointUnreachable ? (
+              <ReachError>
+                <span>Server cannot be reached</span>
+                <Spinner />
+              </ReachError>
+            ) : (
+              <ReloadIcon
+                isReloadingSchema={this.props.isReloadingSchema}
+                onReloadSchema={this.props.refetchSchema}
+              />
+            )}
+          </UrlBarWrapper>
+          <Button desktopOnly={true} onClick={this.copyCurlToClipboard}>
+            Copy CURL
+          </Button>
+          <Button mobileOnly={true} onClick={this.toggleMobileMenu}>
+            Menu
+          </Button>
+          {this.props.shareEnabled && (
+            <Share>
+              <Button>Share Playground</Button>
+            </Share>
           )}
-        </UrlBarWrapper>
-        <Button onClick={this.copyCurlToClipboard}>Copy CURL</Button>
-        {this.props.shareEnabled && (
-          <Share>
-            <Button>Share Playground</Button>
-          </Share>
-        )}
+        </TopBarInnerWrapper>
+        <MobileMenu mobileOnly={true} hidden={!this.state.showMobileMenu}>
+          <Button onClick={this.props.prettifyQuery}>Prettify</Button>
+          <Button onClick={this.openHistory}>History</Button>
+          <Button onClick={this.copyCurlToClipboard}>Copy CURL</Button>
+        </MobileMenu>
       </TopBarWrapper>
     )
   }
   copyCurlToClipboard = () => {
     const curl = this.getCurl()
     copy(curl)
+  }
+  toggleMobileMenu = () => {
+    this.setState({ showMobileMenu: !this.state.showMobileMenu })
   }
   onChange = e => {
     this.props.editEndpoint(e.target.value)
@@ -165,22 +189,37 @@ export const Button = styled.button`
   font-size: 14px;
   padding: 6px 9px 7px 10px;
   margin-left: 6px;
+  @media screen and (min-width: 768px) {
+    display: ${p => p.mobileOnly && `none`};
+  }
+  @media screen and (max-width: 767px) {
+    display: ${p => p.desktopOnly && `none`};
+  }
 
   cursor: pointer;
   transition: 0.1s linear background-color;
-  &:first-child {
-    margin-left: 0;
-  }
   &:hover {
     background-color: ${p => p.theme.editorColours.buttonHover};
   }
 `
 
+const MobileMenu = styled.div`
+  padding: 10px 0 0;
+  @media screen and (min-width: 768px) {
+    display: ${p => p.mobileOnly && `none`};
+  }
+`
+
 const TopBarWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   background: ${p => p.theme.editorColours.navigationBar};
-  padding: 10px 10px 4px;
-  align-items: center;
+  padding: 10px 10px 4px 4px;
+  justify-content: center;
+`
+
+const TopBarInnerWrapper = styled.div`
+  display: flex;
 `
 
 interface UrlBarProps {


### PR DESCRIPTION
Fixes #620.

Note: Not entirely done, but opening for discussion and tracking.

Changes proposed in this pull request:

- Hide the Prettify, History, Copy CURL buttons on mobile, moved to a "Menu" row added below the URL bar
- Make the editor/results fallback to horizontal on mobile, and adjust the execute query button

TODO:

- Adjust the history modal to be responsive (open to suggestions)
- Improve behavior of the Docs window (it's bearable on desktop, but very annoying to use on mobile


