### PR TITLE
Close sidebar on pressing escape

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
@@ -98,7 +98,13 @@ class SideTabs extends React.Component<
     if (prevProps.activeTabIdx && !this.props.docs.activeTabIdx) {
       this.props.setDocsVisible(this.props.sessionId, false)
     }
-    return this.setWidth()
+    this.setWidth()
+    if (
+      this.props.docs.activeTabIdx !== prevProps.docs.activeTabIdx &&
+      this.refContentContainer
+    ) {
+      this.refContentContainer.focus()
+    }
   }
 
   componentDidMount() {
@@ -164,9 +170,6 @@ class SideTabs extends React.Component<
   }
 
   private handleTabClick = idx => () => {
-    if (!this.props.docs.docsOpen && this.refContentContainer) {
-      this.refContentContainer.focus()
-    }
     if (this.props.docs.activeTabIdx === idx) {
       this.props.setDocsVisible(this.props.sessionId, false)
       return this.setWidth()

--- a/packages/graphql-playground-react/src/components/Playground/SchemaExplorer/SDLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/SchemaExplorer/SDLEditor.tsx
@@ -152,11 +152,11 @@ const Editor = styled.div`
   }
 `
 const OverflowShadow = styled.div`
-	position: fixed:
-	top: 0;
-	left: 0;
-	right: 0;
-	height: 1px;
-	box-shadow: 0px 1px 3px rgba(17, 17, 17, 0.1);
-	z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  box-shadow: 0px 1px 3px rgba(17, 17, 17, 0.1);
+  z-index: 1000;
 `


### PR DESCRIPTION
Fixes #907.

Actually, the code to power the closing via keyboard handler was already in place. But the focus state of the sidebar was not managed properly so the sidebar was not closing.

This PR address the focus management