### PR TITLE
Support non primitive types for default value

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/TypeLink.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/TypeLink.tsx
@@ -166,7 +166,7 @@ class TypeLink extends React.Component<
         {type.defaultValue !== undefined ? (
           <DefaultValue>
             {' '}
-            = <span>{`${type.defaultValue}`}</span>
+            = <span>{`${JSON.stringify(type.defaultValue, null, 2)}`}</span>
           </DefaultValue>
         ) : (
           undefined


### PR DESCRIPTION
Fixes #903.

We now run JSON.stringify on type.default so that it is always a string and can be displayed.


There is no chance there will a circular object in the default values so this should fix the current problem

