### PR TITLE
Update headers are empty check on INJECT_HEADERS

### DIFF
--- a/packages/graphql-playground-react/src/state/sessions/reducers.ts
+++ b/packages/graphql-playground-react/src/state/sessions/reducers.ts
@@ -32,7 +32,8 @@ export interface SessionStateProps {
   sessions: OrderedMap<string, Session>
   selectedSessionId: string
   sessionCount: number
-  headers?: string
+  
+  ?: string
 }
 
 export interface Tab {
@@ -447,7 +448,7 @@ const reducer = handleActions(
     // it makes sure, that there definitely is a tab open with the correct header
     INJECT_HEADERS: (state, { payload: { headers, endpoint } }) => {
       // if there are no headers to inject, there's nothing to do
-      if (!headers || headers === '') {
+      if (!headers || headers === '' || Object.keys(headers).length === 0) {
         return state
       }
       const headersString =

--- a/packages/graphql-playground-react/src/state/sessions/reducers.ts
+++ b/packages/graphql-playground-react/src/state/sessions/reducers.ts
@@ -32,8 +32,7 @@ export interface SessionStateProps {
   sessions: OrderedMap<string, Session>
   selectedSessionId: string
   sessionCount: number
-  
-  ?: string
+  headers?: string
 }
 
 export interface Tab {


### PR DESCRIPTION
An empty headers dict currently is not treated as having 'no headers to inject'
Discussed in: https://github.com/prisma/graphql-playground/issues/893

Fixes #893 (at least in the case where headers are empty).

Changes proposed in this pull request:

-  Fix logic in checking if headers are empty in INJECT_HEADERS