### PR TITLE
send the subscription endpoint as parameter to link creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ interface Tab {
 In addition to this, the React app provides some more properties:
 
 - `props` (React Component)
-- `createApolloLink` [`(session: Session) => ApolloLink`] - this is the equivalent to the `fetcher` of GraphiQL. For each query that is being executed, this function will be called
+- `createApolloLink` [`(session: Session, subscriptionEndpoint?: string) => ApolloLink`] - this is the equivalent to the `fetcher` of GraphiQL. For each query that is being executed, this function will be called
 
 `createApolloLink` is only available in the React Component and not the middlewares, because the content must be serializable as it is being printed into a HTML template.
 

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -84,7 +84,10 @@ export interface Props {
   fixedEndpoints: boolean
   headers?: any
   configPath?: string
-  createApolloLink?: (session: Session) => ApolloLink
+  createApolloLink?: (
+    session: Session,
+    subscriptionEndpoint?: string,
+  ) => ApolloLink
   workspaceName?: string
   schema?: GraphQLSchema
 }

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -57,7 +57,10 @@ export interface PlaygroundWrapperProps {
   config?: GraphQLConfig
   configPath?: string
   injectedState?: any
-  createApolloLink?: (session: Session) => ApolloLink
+  createApolloLink?: (
+    session: Session,
+    subscriptionEndpoint?: string,
+  ) => ApolloLink
   tabs?: Tab[]
   schema?: { __schema: any } // introspection result
   codeTheme?: EditorColours


### PR DESCRIPTION
Fixes #919

Changes proposed in this pull request:

- Make sure the subscription endpoint is sent as a parameter to link creator to make it more straight forward to build a custom link creator

Let me know if you think this is reasonable, and I'll update the type specifications and documentation to reflect this as well. 