### PR TITLE
Remove hardcoded favicon.

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -59,7 +59,7 @@ export interface RenderPageOptions extends MiddlewareOptions {
   cdnUrl?: string
   env?: any
   title?: string
-  faviconUrl?: string
+  faviconUrl?: string | null
 }
 
 export interface Tab {
@@ -76,9 +76,10 @@ const getCdnMarkup = ({ version, cdnUrl = '//cdn.jsdelivr.net/npm', faviconUrl }
     <link rel="stylesheet" href="${cdnUrl}/graphql-playground-react${
   version ? `@${version}` : ''
 }/build/static/css/index.css" />
-    <link rel="shortcut icon" href="${faviconUrl ? faviconUrl : `${cdnUrl}/graphql-playground-react${
+    ${typeof faviconUrl === 'string' ? `<link rel="shortcut icon" href="${faviconUrl}" />` : ''}
+    ${faviconUrl === undefined ? `<link rel="shortcut icon" href="${cdnUrl}/graphql-playground-react${
       version ? `@${version}` : ''
-    }/build/favicon.png`}" />
+    }/build/favicon.png" />` : ''}
     <script src="${cdnUrl}/graphql-playground-react${
   version ? `@${version}` : ''
 }/build/static/js/middleware.js"></script>

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -107,7 +107,6 @@ export function renderPlaygroundPage(options: RenderPageOptions) {
   <head>
     <meta charset=utf-8 />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-    <link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700" rel="stylesheet">
     <title>${extendedOptions.title || 'GraphQL Playground'}</title>
     ${

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -59,6 +59,7 @@ export interface RenderPageOptions extends MiddlewareOptions {
   cdnUrl?: string
   env?: any
   title?: string
+  faviconUrl?: string
 }
 
 export interface Tab {
@@ -71,13 +72,13 @@ export interface Tab {
 
 const loading = getLoadingMarkup()
 
-const getCdnMarkup = ({ version, cdnUrl = '//cdn.jsdelivr.net/npm' }) => `
+const getCdnMarkup = ({ version, cdnUrl = '//cdn.jsdelivr.net/npm', faviconUrl }) => `
     <link rel="stylesheet" href="${cdnUrl}/graphql-playground-react${
   version ? `@${version}` : ''
 }/build/static/css/index.css" />
-    <link rel="shortcut icon" href="${cdnUrl}/graphql-playground-react${
-  version ? `@${version}` : ''
-}/build/favicon.png" />
+    <link rel="shortcut icon" href="${faviconUrl ? faviconUrl : `${cdnUrl}/graphql-playground-react${
+      version ? `@${version}` : ''
+    }/build/favicon.png`}" />
     <script src="${cdnUrl}/graphql-playground-react${
   version ? `@${version}` : ''
 }/build/static/js/middleware.js"></script>

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -58,6 +58,7 @@ export interface RenderPageOptions extends MiddlewareOptions {
   version?: string
   cdnUrl?: string
   env?: any
+  title?: string
 }
 
 export interface Tab {


### PR DESCRIPTION
Fixes #921.
Fixes #216.

Changes proposed in this pull request:

- Remove the hardcoded favicon `graphcool-playground.netlify.com` path.
This hardcoded path never actually did anything as it was replaced by a further `shortcut icon` link after, so is being removed for hygiene.

Before:
```
<link rel="shortcut icon" href="https://graphcool-playground.netlify.com/favicon.png">
<title>GraphQL Playground</title>
<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/static/css/index.css" />
<link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/favicon.png" />
```
After:
```
<title>GraphQL Playground</title>
<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/static/css/index.css" />
<link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/favicon.png" />
```