### PR TITLE
Update playgroundVersion to the latest version

### DIFF
--- a/packages/graphql-playground-middleware-express/package.json
+++ b/packages/graphql-playground-middleware-express/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "playgroundVersion": "1.7.8",
+  "playgroundVersion": "1.7.11",
   "scripts": {
     "build": "rimraf dist && tsc",
     "prepare": "npm run build"


### PR DESCRIPTION
Fixes #927.

Changes proposed in this pull request:

- update playgroundVersion (graphl-playground-react) to the latest version (1.7.1)
