### PR TITLE
add editor.cursorShape to ISettings interface

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -12,9 +12,12 @@ export interface MiddlewareOptions {
   codeTheme?: EditorColours
 }
 
+export type CursorShape = 'line' | 'block' | 'underline'
 export type Theme = 'dark' | 'light'
+
 export interface ISettings {
   'general.betaUpdates': boolean
+  'editor.cursorShape': CursorShape
   'editor.theme': Theme
   'editor.reuseHeaders': boolean
   'tracing.hideTracingResponse': boolean


### PR DESCRIPTION
This PR adds the `editor.cursorShape` key to the `ISettings` interface.