### PR TITLE
Schema polling refresh issue

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/TopBar/Polling.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/Polling.tsx
@@ -3,7 +3,6 @@ import PollingIcon from './PollingIcon'
 
 export interface Props {
   interval: number
-  isReloadingSchema: boolean
   onReloadSchema: () => void
 }
 
@@ -47,9 +46,7 @@ class SchemaPolling extends React.Component<Props, State> {
     }
   }
   componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.isReloadingSchema !== this.props.isReloadingSchema) {
-      this.updatePolling(nextProps)
-    }
+    this.updatePolling(nextProps)
   }
 
   render() {
@@ -57,7 +54,7 @@ class SchemaPolling extends React.Component<Props, State> {
   }
   private updatePolling = (props: Props = this.props) => {
     this.clearTimer()
-    if (!props.isReloadingSchema && this.state.windowVisible) {
+    if (this.state.windowVisible) {
       // timer starts only when introspection not in flight
       this.timer = setInterval(() => props.onReloadSchema(), props.interval)
     }

--- a/packages/graphql-playground-react/src/components/Playground/TopBar/SchemaReload.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/SchemaReload.tsx
@@ -15,7 +15,6 @@ export default (props: Props) => {
     return (
       <Polling
         interval={props.settings['schema.polling.interval']}
-        isReloadingSchema={props.isReloadingSchema}
         onReloadSchema={props.onReloadSchema}
       />
     )

--- a/packages/graphql-playground-react/src/state/sessions/selectors.ts
+++ b/packages/graphql-playground-react/src/state/sessions/selectors.ts
@@ -71,11 +71,15 @@ export const getIsPollingSchema = createSelector(
   [getEndpoint, getSettings],
   (endpoint, settings) => {
     const json = JSON.parse(settings)
-    return (
-      json['schema.polling.enable'] &&
-      endpoint.match(`/${json['schema.polling.endpointFilter']}`) &&
-      true
-    )
+    try {
+      const isPolling =
+        json['schema.polling.enable'] &&
+        endpoint.match(`/${json['schema.polling.endpointFilter']}`) &&
+        true
+      return isPolling
+    } catch (e) {
+      return false
+    }
   },
 )
 


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:

- Regarding "If there’s an active introspection query, wait for it’s result before sending another one" is default behavior when schema is reloading. The changes I made to account for this in #950 are unnecessary and actually cause polling to stop if the endpoint is unreachable.