### PR TITLE
Restored package.json license fields to MIT

### DIFF
--- a/packages/graphql-playground-html/package.json
+++ b/packages/graphql-playground-html/package.json
@@ -9,7 +9,7 @@
     "Mohammad Rajabifard <mo.rajbi@gmail.com>"
   ],
   "repository": "http://github.com/graphcool/graphql-playground.git",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/packages/graphql-playground-middleware-express/package.json
+++ b/packages/graphql-playground-middleware-express/package.json
@@ -9,7 +9,7 @@
     "Mohammad Rajabifard <mo.rajbi@gmail.com>"
   ],
   "repository": "http://github.com/graphcool/graphql-playground.git",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/packages/graphql-playground-middleware-hapi/package.json
+++ b/packages/graphql-playground-middleware-hapi/package.json
@@ -10,7 +10,7 @@
     "Drake Costa <drake@saeris.io>"
   ],
   "repository": "http://github.com/graphcool/graphql-playground.git",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/packages/graphql-playground-middleware-koa/package.json
+++ b/packages/graphql-playground-middleware-koa/package.json
@@ -9,7 +9,7 @@
     "Mohammad Rajabifard <mo.rajbi@gmail.com>"
   ],
   "repository": "http://github.com/graphcool/graphql-playground.git",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/packages/graphql-playground-middleware-lambda/package.json
+++ b/packages/graphql-playground-middleware-lambda/package.json
@@ -9,7 +9,7 @@
     "Mohammad Rajabifard <mo.rajbi@gmail.com>"
   ],
   "repository": "http://github.com/graphcool/graphql-playground.git",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "http://github.com/graphcool/graphql-playground.git"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "scripts": {
     "start": "node scripts/start.js",
     "start:analyze": "ANALYZE_BUNDLE=true node scripts/start.js",


### PR DESCRIPTION
Reverting license fields back to MIT to restore automated license-testing consumers

Fixes #959 .

Changes proposed in this pull request:

- Restored the license fields in each package.json to be the proper SPDX identifier: `"MIT"`
