### PR TITLE
Avoid calling next() in Express middleware

### DIFF
--- a/packages/graphql-playground-middleware-express/src/index.ts
+++ b/packages/graphql-playground-middleware-express/src/index.ts
@@ -22,7 +22,6 @@ const express: Register = function voyagerExpress(options: MiddlewareOptions) {
     const playground = renderPlaygroundPage(options)
     res.write(playground)
     res.end()
-    next()
   }
 }
 


### PR DESCRIPTION
Fixes #557.
Fixes #752.

Changes proposed in this pull request:
- Avoid calling `next()` in express middleware after `res.end()`. This causes other middleware to be called afterward, and since this is a rendering middleware, it will throw

`[ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`