### PR TITLE
Add hide menu option on mac

### DIFF
--- a/packages/graphql-playground-electron/src/main/menu.ts
+++ b/packages/graphql-playground-electron/src/main/menu.ts
@@ -42,8 +42,12 @@ export const buildTemplate = (
       {
         label: 'Hide GraphQL Playground',
         accelerator: 'Cmd+H',
-        visible: process.platform === 'darwin',
-        click: () => app.hide(),
+        role: 'hide',
+      },
+      {
+        label: 'Hide Others',
+        accelerator: 'Option+Cmd+H',
+        role: 'hideOthers',
       },
       { type: 'separator', visible: process.platform === 'darwin' },
       {

--- a/packages/graphql-playground-electron/src/main/menu.ts
+++ b/packages/graphql-playground-electron/src/main/menu.ts
@@ -49,6 +49,10 @@ export const buildTemplate = (
         accelerator: 'Option+Cmd+H',
         role: 'hideOthers',
       },
+      {
+        label: 'Show All',
+        role: 'unhide',
+      },
       { type: 'separator', visible: process.platform === 'darwin' },
       {
         label: 'Quit',

--- a/packages/graphql-playground-electron/src/main/menu.ts
+++ b/packages/graphql-playground-electron/src/main/menu.ts
@@ -40,6 +40,13 @@ export const buildTemplate = (
       },
       { type: 'separator' },
       {
+        label: 'Hide GraphQL Playground',
+        accelerator: 'Cmd+H',
+        visible: process.platform === 'darwin',
+        click: () => app.hide(),
+      },
+      { type: 'separator', visible: process.platform === 'darwin' },
+      {
         label: 'Quit',
         accelerator: 'CmdOrCtrl+Q',
         click: () => app.quit(),


### PR DESCRIPTION
Fixes #964

Changes proposed in this pull request:

- New menu option to hide the application + separator, both visible only on mac

Couldn't find any info regarding the `Hide Others` electron api tho, please let me know if I've missed it and its implemented.