### PR TITLE
Adjust dragging area

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/Tab.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/Tab.tsx
@@ -142,6 +142,7 @@ interface TabItemProps {
 }
 
 const TabItem = styled<TabItemProps, 'div'>('div')`
+  -webkit-app-region: no-drag;
   flex: 0 0 auto;
   display: flex;
   align-items: center;

--- a/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
@@ -127,6 +127,7 @@ interface PlusProps {
 }
 
 const Plus = styled<PlusProps, 'div'>('div')`
+  -webkit-app-region: no-drag;
   box-sizing: border-box;
   display: flex;
   visibility: ${p => (p.sorting ? 'hidden' : 'visible')}

--- a/packages/graphql-playground-react/src/components/ProjectsSideNav.tsx
+++ b/packages/graphql-playground-react/src/components/ProjectsSideNav.tsx
@@ -146,6 +146,7 @@ const TitleRow = styled.div`
   justify-content: space-evenly;
   margin: 0 15px 20px 15px;
   svg {
+    -webkit-app-region: no-drag;
     min-width: 18px;
     min-height: 18px;
     cursor: pointer;


### PR DESCRIPTION
Fixes #973 .

Apparently reordering tabs is already implemented, but got overwritten by the dragging area of the tab bar and it's wasn't possible to grab them. Furthermore, I've added the no-drag to config icon and plus icon as it seemed to be more intuitive.
