### PR TITLE
Inline sources contents in source map files

### DIFF
--- a/packages/graphql-playground-react/tsconfig.build.json
+++ b/packages/graphql-playground-react/tsconfig.build.json
@@ -4,6 +4,7 @@
     "target": "es5",
     "lib": ["esnext", "dom"],
     "sourceMap": true,
+    "inlineSources": true,
     "jsx": "preserve",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Changes proposed in this pull request:

- Inline sources contents in source map files. 

The current behavior is for `.map` files to refer to the source file. The issue is that the `src` directory is not part of the NPM package, which makes this package's source maps useless as they point to non-existent files. This causes a lot of warnings with `source-map-loader`.

This proposed change makes it so the content of source files gets inlined in the `.map` files, so there is no actual need to read the source files.

Another way to do this would be to bundle the `src` directory within the NPM package.