### PR TITLE
Add missing name field to tab interface

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -65,6 +65,7 @@ export interface RenderPageOptions extends MiddlewareOptions {
 export interface Tab {
   endpoint: string
   query: string
+  name?: string
   variables?: string
   responses?: string[]
   headers?: { [key: string]: string }


### PR DESCRIPTION
Changes proposed in this pull request:

- Ability to set a `name` on `Tab` interface in `graphql-playground-html` package. 

Setting it works fine already but TypeScripts complains as it doesn't see this as a valid field. 