### PR TITLE
Remove internal scrollbars for subscription results

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ResultViewer.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ResultViewer.tsx
@@ -139,6 +139,13 @@ const Result = styled<ResultProps, 'div'>('div')`
     max-width: 50vw;
     margin-right: 10px;
   }
+  .CodeMirror-sizer {
+    margin-bottom: 0 !important;
+  }
+  .CodeMirror-lines {
+    margin: 20px 0;
+    padding: 0;
+  }
   .cm-string {
     color: ${p => p.theme.editorColours.property} !important;
   }


### PR DESCRIPTION
Fixes #.

Problem: When working with subscriptions, each subscription item had a little scrollbar attached to each item. This would make scrolling janky. This pull request removes this double scrollbar.

