### PR TITLE
Fix intersection of macOS traffic lights with the tab bar

### DIFF
--- a/packages/graphql-playground-electron/src/renderer/components/App.tsx
+++ b/packages/graphql-playground-electron/src/renderer/components/App.tsx
@@ -587,6 +587,11 @@ class App extends React.Component<ReduxProps, State> {
           body .root.noConfig .tabs {
             padding-left: 80px;
           }
+          .playground {
+            height: 100vh;
+            padding: 10px 0;
+            box-sizing: border-box;
+          }
         `}</style>
         <style jsx={true}>{`
           .root {


### PR DESCRIPTION
Moves all content down by 10px so the macOS quit, minimize and fullscreen buttons do not intersect with the tab bar. 
This is a common problem with frameless Electron windows.