### PR TITLE
fix(graphql-playground-react): prevent selection of text

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExecuteButton.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExecuteButton.tsx
@@ -220,6 +220,7 @@ const Button = styled<ButtonProps, 'div'>('div')`
       : p.theme.editorColours.executeButton};
   border: 6px solid ${p => p.theme.editorColours.executeButtonBorder};
   cursor: pointer;
+  user-select: none;
 
   svg {
     fill: ${p => (p.theme.mode === 'light' ? 'white' : 'inherit')};
@@ -242,6 +243,7 @@ const ExecuteBox = styled.div`
   position: absolute;
   top: 78px;
   z-index: 100;
+  user-select: none;
 
   &:before {
     position: absolute;


### PR DESCRIPTION
Changes proposed in this pull request:

- prevent selection of text when one did mousedown on the execute button or the execute box and then did mouseup outside of them.

the version not fixed
![SelectionOfText](https://user-images.githubusercontent.com/7870808/54864868-8d2aa880-4da0-11e9-961c-ad5b33a294f1.gif)
