### PR TITLE
fix: 'false' into a non-boolean attribute 'color'

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
@@ -143,7 +143,7 @@ class SideTabs extends React.Component<
           onKeyDown={this.handleKeyDown}
           onMouseMove={this.handleMouseMove}
           tabIndex={activeTabIdx}
-          color={activeTab && activeTab.props.activeColor}
+          color={activeTab ? activeTab.props.activeColor : undefined}
           ref={this.setContentContainerRef}
         >
           {activeTab &&
@@ -344,7 +344,8 @@ const TabContentContainer = styled.div`
   &::before {
     top: 0;
     bottom: 0;
-    background: ${props => props.theme.colours[props.color] || '#3D5866'};
+    background: ${props =>
+      props.color ? props.theme.colours[props.color] : '#3D5866'};
     position: absolute;
     z-index: 3;
     left: 0px;


### PR DESCRIPTION
Changes proposed in this pull request:

- This PR for resolving the following console warning, which appears when a side tab isn't active.

```
Warning: Received `false` for a non-boolean attribute `color`.

If you want to write it to the DOM, pass a string instead: color="false" or color={value.toString()}.

If you used to conditionally omit it with color={condition && value}, pass color={condition ? value : undefined} instead.
```
