### PR TITLE
fix(graphql-playground-react): not update schema

### DIFF
--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -342,7 +342,11 @@ class PlaygroundWrapper extends React.Component<
 
     const defaultHeaders = this.props.headers || {}
     const stateHeaders = this.state.headers || {}
-    const combinedHeaders = { ...defaultHeaders, ...stateHeaders }
+    const combinedHeaders =
+      Object.keys(defaultHeaders).length > 0 ||
+      Object.keys(stateHeaders).length > 0
+        ? { ...defaultHeaders, ...stateHeaders }
+        : undefined
 
     const { theme } = this.props
     return (


### PR DESCRIPTION
When you get a new GraphQL schema by introspecting, the schema won't be updated from the previous one unless headers are set. This commit fixes it.

Fixes #965 .

Changes proposed in this pull request:

- 

- 

- 
