### PR TITLE
Set default shareEnabled to true

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -137,7 +137,7 @@ export { GraphQLEditor }
 
 export class Playground extends React.PureComponent<Props & ReduxProps, State> {
   static defaultProps = {
-    shareEnabled: false,
+    shareEnabled: true,
   }
 
   apolloLinks: { [sessionId: string]: any } = {}


### PR DESCRIPTION
It seems like this was accidentally introduced in some UI fixes (https://github.com/prisma/graphql-playground/commit/273697ecf42dfd38720c473674415b318fda10d5#diff-de99fb113c90fc40c0f1349bddf05b09)
The PR (#642) that added shareEnabled set default to true

Fixes #983

Changes proposed in this pull request:
- `shareEnabled` defaults to true
- graphqlbin.com will have share button
