### PR TITLE
fix typo in downloaded schema filename

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/util/createSDL.ts
+++ b/packages/graphql-playground-react/src/components/Playground/util/createSDL.ts
@@ -116,7 +116,7 @@ export function downloadSchema(schema: GraphQLSchema, type: string) {
     return download(data, filename)
   } else {
     const data = JSON.stringify(schema)
-    const filename = 'instrospectionSchema.json'
+    const filename = 'introspectionSchema.json'
     return download(data, filename)
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- fix the filename given to the schema when downloaded using the JSON download button in the schema viewer
