### PR TITLE
Fix side tabs resize

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
@@ -6,6 +6,7 @@ import { getLeft } from 'graphiql/dist/utility/elementPosition'
 import {
   addStack,
   toggleDocs,
+  changeWidthDocs,
   changeKeyMove,
   setDocsVisible,
 } from '../../../state/docs/actions'
@@ -249,6 +250,7 @@ const mapDispatchToProps = dispatch =>
     {
       addStack,
       toggleDocs,
+      changeWidthDocs,
       changeKeyMove,
       setDocsVisible,
     },


### PR DESCRIPTION
Fixes side tab resizing

Changes proposed in this pull request:

- Bind missing action `changeWidthDocs` so that the tabs can resize

---

This issue was originally reported in https://github.com/apollographql/apollo-server/issues/2529 and was fixed in https://github.com/apollographql/graphql-playground/pull/19. 

The regression looks like it was introduced in https://github.com/prisma/graphql-playground/pull/1001.
