### PR TITLE
Render markdown for enum member documentation. Fixes #1081.

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/DocsTypes/EnumTypeSchema.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/DocsTypes/EnumTypeSchema.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { styled } from '../../../../styled'
 import { DocType } from './DocType'
+import MarkdownContent from 'graphiql/dist/components/DocExplorer/MarkdownContent'
 
 export interface EnumTypeSchemaProps {
   type: any
@@ -45,11 +46,9 @@ interface ValueProps {
 const Value = ({ value, isDeprecated, first }: ValueProps) => (
   <DocsValue first={first}>
     <div className="field-name">{value.name}</div>
-    {value.description && (
-      <DocsValueComment>{value.description}</DocsValueComment>
-    )}
+    {value.description && <DocsValueComment markdown={value.description} />}
     {isDeprecated && (
-      <DocsValueComment>Deprecated: {value.deprecationReason}</DocsValueComment>
+      <DocsValueComment markdown={'Deprecated: ' + value.deprecationReason} />
     )}
   </DocsValue>
 )
@@ -66,7 +65,7 @@ const DocsValue = styled<DocsValueProps, 'div'>('div')`
   }
 `
 
-const DocsValueComment = styled.div`
+const DocsValueComment = styled(MarkdownContent)`
   padding: 0 16px;
   color: ${p => p.theme.colours.black50};
 `


### PR DESCRIPTION
Fixes #1081 .

Changes proposed in this pull request:
- Render markdown for enum member documentation

Before:
![before](https://user-images.githubusercontent.com/6171713/64650949-4c8b1e00-d418-11e9-94fc-c5d57769701c.png)
After:
![after](https://user-images.githubusercontent.com/6171713/64650955-4e54e180-d418-11e9-973d-bc779523dc7e.png)

