### PR TITLE
Allow the playground to assume height of the container

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -451,7 +451,7 @@ const PlaygroundContainer = styled.div`
 `
 
 const GraphiqlsContainer = styled.div`
-  height: calc(100vh - 57px);
+  height: 100%;
   position: relative;
   overflow: hidden;
 `

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -346,7 +346,7 @@ class PlaygroundWrapper extends React.Component<
 
     const { theme } = this.props
     return (
-      <div>
+      <Root>
         {title}
         <ThemeProvider
           theme={{
@@ -406,7 +406,7 @@ class PlaygroundWrapper extends React.Component<
             />
           </App>
         </ThemeProvider>
-      </div>
+      </Root>
     )
   }
 
@@ -567,7 +567,12 @@ const appearIn = keyframes`
 const App = styled.div`
   display: flex;
   width: 100%;
+  height: 100%;
   opacity: 0;
   transform: translateY(10px);
   animation: ${appearIn} 0.5s ease-out forwards 0.2s;
+`
+
+const Root = styled.div`
+  height: 100%;
 `


### PR DESCRIPTION
Fixes # NA

# Motivation

I need to embed the playground into an app that has it's own header and footer. The playground overlap the app's header and footer because the CSS assumes that the playground will consume the entire page. 

Here is a screenshot of what I would like to be able to achieve.

<img width="1029" alt="Screen Shot 2019-12-05 at 10 44 37 PM" src="https://user-images.githubusercontent.com/74687/70296623-e1e84500-17b0-11ea-8549-eb7ab049e85f.png">

# Approach

I removed the user of 100vh and added 100% height to containers that constrain the playground. I tested the result in Chrome and Safari. 

# Screenshots

## Before

![2019-12-05 22 39 36](https://user-images.githubusercontent.com/74687/70296541-a188c700-17b0-11ea-8105-e5f5fbd1b33e.gif)

## After

![2019-12-05 22 38 45](https://user-images.githubusercontent.com/74687/70296852-5e7b2380-17b1-11ea-8012-49d0ef7f76ac.gif)

