### PR TITLE
chore(security): security monitoring for example lockfiles

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -80,3 +80,53 @@ update_configs:
       prefix: 'fix'
       prefix_development: 'fix'
       include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-hapi/examples/basic'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-express/examples/basic'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-express/examples/graphcool'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-lambda/examples/basic'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-koa/examples/basic'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true


### PR DESCRIPTION
i think this is the final security fix! no yarn workspaces, dependabot cannot auto-manage many `yarn.lock` files