### PR TITLE
[graphql-playground-react] multiple rows tab bar

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TabBar.tsx
@@ -5,6 +5,7 @@ import Tab, { Props as TabProps } from './Tab'
 import { connect } from 'react-redux'
 import { createStructuredSelector } from 'reselect'
 import {
+  getMultipleRows,
   getSessionsArray,
   getSelectedSessionIdFromRoot,
 } from '../../state/sessions/selectors'
@@ -23,6 +24,7 @@ export interface Props {
 }
 
 export interface ReduxProps {
+  multipleRows: boolean
   sessions: Session[]
   selectedSessionId: string
   reorderTabs: (src: number, dest: number) => void
@@ -38,20 +40,21 @@ class TabBar extends React.PureComponent<Props & ReduxProps, State> {
   state = { sorting: false }
 
   render() {
-    const { sessions, isApp, selectedSessionId, onNewSession } = this.props
+    const { sessions, isApp, selectedSessionId, onNewSession, multipleRows } = this.props
     const { sorting } = this.state
     return (
+        <MultipleRows multiple_rows={multipleRows}>
       <SortableTabBar
         onSortStart={this.onSortStart}
         onSortEnd={this.onSortEnd}
         getHelperDimensions={this.getHelperDimensions}
-        axis="x"
-        lockAxis="x"
+        axis={multipleRows ? 'xy' : 'x'}
+        lockAxis={multipleRows ? 'xy' : 'x'}
         lockToContainerEdges={true}
         distance={10}
         transitionDuration={200}
       >
-        <Tabs isApp={isApp}>
+        <Tabs isApp={isApp} multiple_rows={multipleRows}>
           {sessions.map((session, ndx) => (
             <SortableTab
               key={session.id}
@@ -70,6 +73,7 @@ class TabBar extends React.PureComponent<Props & ReduxProps, State> {
           </Plus>
         </Tabs>
       </SortableTabBar>
+        </MultipleRows>
     )
   }
 
@@ -90,6 +94,7 @@ class TabBar extends React.PureComponent<Props & ReduxProps, State> {
 
 const mapStateToProps = createStructuredSelector({
   sessions: getSessionsArray,
+  multipleRows: getMultipleRows,
   selectedSessionId: getSelectedSessionIdFromRoot,
 })
 
@@ -115,11 +120,22 @@ interface TabsProps {
   isApp?: boolean
 }
 
+const MultipleRows = styled.div`
+  & > div {
+    height: ${(p) => (p.multiple_rows ? 'auto' : '57px')};
+  }
+`
+
 const Tabs = styled<TabsProps, 'div'>('div')`
   display: flex;
   align-items: center;
-  margin-top: 16px;
+  flex-wrap: ${(p) => (p.multiple_rows ? 'wrap' : 'nowrap')};
+  margin-top: ${(p) => (p.multiple_rows ? '8px' : '16px')};
   padding-left: ${p => (p.isApp ? '43px' : '0')};
+
+  & > div {
+    margin-top: ${(p) => (p.multiple_rows ? '8px' : 0)};
+  }
 `
 
 interface PlusProps {

--- a/packages/graphql-playground-react/src/state/sessions/selectors.ts
+++ b/packages/graphql-playground-react/src/state/sessions/selectors.ts
@@ -127,6 +127,17 @@ export const getUseTabs = createSelector([getSettings], settings => {
   return false
 })
 
+export const getMultipleRows = createSelector([getSettings], (settings) => {
+  try {
+    const json = JSON.parse(settings)
+    return json['tabs.multipleRows'] || false
+  } catch (e) {
+    //
+  }
+
+  return false
+})
+
 export const getHeadersCount = createSelector([getHeaders], headers => {
   try {
     const json = JSON.parse(headers)

--- a/packages/graphql-playground-react/src/state/workspace/reducers.ts
+++ b/packages/graphql-playground-react/src/state/workspace/reducers.ts
@@ -50,6 +50,7 @@ export const defaultSettings: ISettings = {
   'prettier.printWidth': 80,
   'prettier.tabWidth': 2,
   'prettier.useTabs': false,
+  'tabs.multipleRows': false,
   'request.credentials': 'omit',
   'request.globalHeaders': {},
   'schema.disableComments': true,

--- a/packages/graphql-playground-react/src/types.ts
+++ b/packages/graphql-playground-react/src/types.ts
@@ -26,6 +26,7 @@ export interface ISettings {
   ['prettier.printWidth']: number
   ['prettier.tabWidth']: number
   ['prettier.useTabs']: boolean
+  ['tabs.multipleRows']: boolean
   ['request.credentials']: 'omit' | 'include' | 'same-origin'
   ['request.globalHeaders']: { [key: string]: string }
   ['schema.disableComments']: boolean


### PR DESCRIPTION
Changes proposed in this pull request:

- add a new setting `tabs.multipleRows` to split the single tab bar in multiple rows.

![multipleRows](https://user-images.githubusercontent.com/6225939/125159482-ef796400-e177-11eb-8a16-a5fccfd213a4.gif)


Please let me know if you have any concerns. Thanks!