### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/graphql-playground-react/config/paths.js
+++ b/packages/graphql-playground-react/config/paths.js
@@ -14,7 +14,7 @@ const envPublicUrl = process.env.PUBLIC_URL
 function ensureSlash(path, needsSlash) {
   const hasSlash = path.endsWith('/')
   if (hasSlash && !needsSlash) {
-    return path.substr(path, path.length - 1)
+    return path.slice(0, -1)
   } else if (!hasSlash && needsSlash) {
     return `${path}/`
   } else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.