### PR TITLE
Remove leading `$` symbol from the installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew install --cask graphql-playground
+brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
Having leading `$` makes it not possible to directly execute the snippet in the terminal.