### PR TITLE
Wraps metadata charset definition in double-quotes.

### DIFF
--- a/packages/graphql-playground-html/minimal.html
+++ b/packages/graphql-playground-html/minimal.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <meta charset=utf-8/>
+  <meta charset="utf-8"/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />


### PR DESCRIPTION
Encoding meta definitions should be wrapped in quotes, like other HTML attributes. See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#examples

Was found because it caused an error in the characters used for code folding.

Changes proposed in this pull request:

- Wrap metadata charset attribute in double-quotes.