### PR TITLE
Remove unnecessary prompt character from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew install --cask graphql-playground
+brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
As the title says.

The `$` is not necessary and actually undermines the "copy" feature that GitHub offers for code snippets.