### PR TITLE
Replaced DOMNodeRemoved event by MutationObserver

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -425,14 +425,18 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
   private handleHintInformationRender = elem => {
     elem.addEventListener('click', this.onClickHintInformation)
 
-    let onRemoveFn
-    elem.addEventListener(
-      'DOMNodeRemoved',
-      (onRemoveFn = () => {
-        elem.removeEventListener('DOMNodeRemoved', onRemoveFn)
-        elem.removeEventListener('click', this.onClickHintInformation)
-      }),
-    )
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.removedNodes.forEach((removedNode) => {
+          if (removedNode === elem) {
+            elem.removeEventListener('click', this.onClickHintInformation);
+            observer.disconnect();
+          }
+        });
+      });
+    });
+
+    observer.observe(elem, { childList: true });
   }
 
   private handleResizeStart = downEvent => {

--- a/packages/graphql-playground-react/src/components/Playground/onHasCompletion.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/onHasCompletion.tsx
@@ -87,19 +87,20 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
       // When CodeMirror attempts to remove the hint UI, we detect that it was
       // removed from our wrapper and in turn remove the wrapper from the
       // original container.
-      let onRemoveFn
-      wrapper.addEventListener(
-        'DOMNodeRemoved',
-        (onRemoveFn = event => {
-          if (event.target === hintsUl) {
-            wrapper.removeEventListener('DOMNodeRemoved', onRemoveFn)
-            wrapper.parentNode.removeChild(wrapper)
-            wrapper = null
-            information = null
-            onRemoveFn = null
-          }
-        }),
-      )
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.removedNodes.forEach((removedNode) => {
+            if (removedNode === hintsUl) {
+              wrapper.parentNode.removeChild(wrapper);
+              wrapper = null;
+              information = null;
+              observer.disconnect();
+            }
+          });
+        });
+      });
+
+      observer.observe(wrapper, { childList: true });
     }
 
     // Now that the UI has been set up, add info to information.


### PR DESCRIPTION
Fixes #.

DOMNodeRemoved event is now [deprecated an unsupported](https://developer.chrome.com/blog/mutation-events-deprecation) by Chrome browser, in favor of [MutationEvent](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent).

The issue is that the tooltip remains on screen and page has to be reloaded for it to disappear, which is very disturbing for the user experience.

![CleanShot 2024-08-29 at 18 53 20@2x](https://github.com/user-attachments/assets/30f8457e-5bfc-4e46-b242-bf14e37bc364)


Changes proposed in this pull request:

Replaced the deprecated event by `MutationObserver`

- 

- 

- 
